### PR TITLE
[8824] Improve shared content browse dialog selection UX

### DIFF
--- a/studio-ui/ui/app/src/components/BrowseFilesDialog/BrowseFilesDialogContainer.tsx
+++ b/studio-ui/ui/app/src/components/BrowseFilesDialog/BrowseFilesDialogContainer.tsx
@@ -209,7 +209,7 @@ export function BrowseFilesDialogContainer(props: BrowseFilesDialogContainerProp
 			const mediaItem = items?.find((searchItem) => searchItem.path === item.path) ?? contentItemToMediaItem(item);
 			multiSelect ? replaceSelectedLookup({ [mediaItem.path]: mediaItem }) : setSelectedCard(mediaItem);
 			setTreeSelectedPath(withoutIndex(mediaItem.path));
-		} else {
+		} else if (treeSelectedPath) {
 			multiSelect ? replaceSelectedLookup() : setSelectedCard(null);
 			setTreeSelectedPath(null);
 		}

--- a/studio-ui/ui/app/src/components/BrowseFilesDialog/BrowseFilesDialogContainer.tsx
+++ b/studio-ui/ui/app/src/components/BrowseFilesDialog/BrowseFilesDialogContainer.tsx
@@ -31,8 +31,7 @@ import EmptyState from '../EmptyState';
 import BrowseFilesDialogContainerSkeleton from './BrowseFilesDialogContainerSkeleton';
 import { getStoredBrowseDialogViewMode, setStoredBrowseDialogViewMode } from '../../utils/state';
 import useActiveUser from '../../hooks/useActiveUser';
-import { withIndex, withoutIndex, isPagePath } from '../../utils/path';
-import { ContentItem } from '../../models/Item';
+import { withIndex, withoutIndex } from '../../utils/path';
 import { MediaCardViewModes } from '../MediaCard';
 import { createPresenceTable } from '../../utils/array';
 import { createLookupTable } from '../../utils/object';
@@ -42,6 +41,7 @@ import { nanoid } from 'nanoid';
 
 import { createComponentId } from '../../utils/system';
 import { useItemsByPath } from '../../hooks/useItemsByPath';
+import { lookupItemByPath } from '../../utils/content';
 
 const defaultPreselectedPaths = [];
 
@@ -200,7 +200,7 @@ export function BrowseFilesDialogContainer(props: BrowseFilesDialogContainerProp
 	};
 
 	const onPathSelected = (path: string) => {
-		const item = itemsByPath[path];
+		const item = lookupItemByPath(path, itemsByPath);
 		const nextPath = withoutIndex(path);
 		setCurrentPath(nextPath);
 

--- a/studio-ui/ui/app/src/components/BrowseFilesDialog/BrowseFilesDialogContainer.tsx
+++ b/studio-ui/ui/app/src/components/BrowseFilesDialog/BrowseFilesDialogContainer.tsx
@@ -203,18 +203,24 @@ export function BrowseFilesDialogContainer(props: BrowseFilesDialogContainerProp
 		const nextPath = withoutIndex(path);
 		setCurrentPath(nextPath);
 
+		// If the selected path is a page and has no children, select the page itself.
 		if (item?.systemType === 'page' && item.childrenCount === 0) {
 			const mediaItem = items?.find((searchItem) => searchItem.path === item.path) ?? contentItemToMediaItem(item);
-			multiSelect ? setSelectedLookup({ [mediaItem.path]: mediaItem }) : setSelectedCard(mediaItem);
+			multiSelect ? replaceSelectedLookup({ [mediaItem.path]: mediaItem }) : setSelectedCard(mediaItem);
 			setTreeSelectedPath(withoutIndex(mediaItem.path));
 		} else {
-			multiSelect ? clearSelectedLookup() : setSelectedCard(null);
+			multiSelect ? replaceSelectedLookup() : setSelectedCard(null);
 			setTreeSelectedPath(null);
 		}
 	};
 
-	const clearSelectedLookup = () => {
-		setSelectedLookup(Object.fromEntries(Object.keys(selectedLookup).map((key) => [key, null])));
+	const replaceSelectedLookup = (lookup?: LookupTable<MediaItem>) => {
+		const cleared = Object.fromEntries(Object.keys(selectedLookup).map((key) => [key, null]));
+		if (!lookup || Object.keys(lookup).length === 0) {
+			setSelectedLookup(cleared);
+		} else {
+			setSelectedLookup({ ...cleared, ...lookup });
+		}
 	};
 
 	const onCloseButtonClick = (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => onClose(e, null);

--- a/studio-ui/ui/app/src/components/BrowseFilesDialog/BrowseFilesDialogContainer.tsx
+++ b/studio-ui/ui/app/src/components/BrowseFilesDialog/BrowseFilesDialogContainer.tsx
@@ -41,6 +41,7 @@ import { popDialog, pushDialog } from '../../state/actions/dialogStack';
 import { nanoid } from 'nanoid';
 
 import { createComponentId } from '../../utils/system';
+import { useItemsByPath } from '../../hooks/useItemsByPath';
 
 const defaultPreselectedPaths = [];
 
@@ -83,6 +84,7 @@ export function BrowseFilesDialogContainer(props: BrowseFilesDialogContainerProp
 		(items?.length > 0 && selectedInCurrentPage.length > 0 && selectedInCurrentPage.length < items?.length) ?? false;
 	const browsePath = path.replace(/\/+$/, '');
 	const [currentPath, setCurrentPath] = useState(browsePath);
+	const [treeSelectedPath, setTreeSelectedPath] = useState<string>();
 	const [fetchingBrowsePathExists, setFetchingBrowsePathExists] = useState(false);
 	const [browsePathExists, setBrowsePathExists] = useState(false);
 	const [sortKeys, setSortKeys] = useState([]);
@@ -91,6 +93,7 @@ export function BrowseFilesDialogContainer(props: BrowseFilesDialogContainerProp
 	const [fetchingPreselectedItems, setFetchingPreselectedItems] = useState(false);
 	const disableSubmission = fetchingPreselectedItems || (!selectedArray.length && !selectedCard);
 	const preselectedLookup = createPresenceTable(preselectedPaths);
+	const itemsByPath = useItemsByPath();
 
 	const fetchItems = useCallback(() => {
 		// Since lookahead regex is not supported by opensearch, we are excluding the current path from the search using a
@@ -195,20 +198,24 @@ export function BrowseFilesDialogContainer(props: BrowseFilesDialogContainerProp
 		setSelectedLookup({ [path]: selected ? items.find((item) => item.path === path) : null });
 	};
 
-	const onPathSelected = (path: string, item?: ContentItem) => {
+	const onPathSelected = (path: string) => {
+		const item = itemsByPath[path];
 		const nextPath = withoutIndex(path);
 		setCurrentPath(nextPath);
 
-		if (!multiSelect && item?.systemType === 'page' && item.childrenCount === 0) {
+		if (item?.systemType === 'page' && item.childrenCount === 0) {
 			const mediaItem = items?.find((searchItem) => searchItem.path === item.path) ?? contentItemToMediaItem(item);
-			setSelectedCard(mediaItem);
-		} else if (!multiSelect) {
-			setSelectedCard(null);
+			multiSelect ? setSelectedLookup({ [mediaItem.path]: mediaItem }) : setSelectedCard(mediaItem);
+			setTreeSelectedPath(withoutIndex(mediaItem.path));
+		} else {
+			multiSelect ? clearSelectedLookup() : setSelectedCard(null);
+			setTreeSelectedPath(null);
 		}
 	};
 
-	const treeSelectedPath =
-		!multiSelect && selectedCard?.path && isPagePath(selectedCard.path) ? selectedCard.path : currentPath;
+	const clearSelectedLookup = () => {
+		setSelectedLookup(Object.fromEntries(Object.keys(selectedLookup).map((key) => [key, null])));
+	};
 
 	const onCloseButtonClick = (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => onClose(e, null);
 

--- a/studio-ui/ui/app/src/components/BrowseFilesDialog/BrowseFilesDialogContainer.tsx
+++ b/studio-ui/ui/app/src/components/BrowseFilesDialog/BrowseFilesDialogContainer.tsx
@@ -94,6 +94,7 @@ export function BrowseFilesDialogContainer(props: BrowseFilesDialogContainerProp
 	const disableSubmission = fetchingPreselectedItems || (!selectedArray.length && !selectedCard);
 	const preselectedLookup = createPresenceTable(preselectedPaths);
 	const itemsByPath = useItemsByPath();
+	const isCurrentPathLeaf = Boolean(treeSelectedPath); // treeSelectedPath is set when a leaf page is selected in the tree view
 
 	const fetchItems = useCallback(() => {
 		// Since lookahead regex is not supported by opensearch, we are excluding the current path from the search using a
@@ -303,6 +304,7 @@ export function BrowseFilesDialogContainer(props: BrowseFilesDialogContainerProp
 			onSelectAll={onSelectAll}
 			allSelected={allSelectedInCurrentPage}
 			someSelected={someSelectedInCurrentPage}
+			isCurrentPathLeaf={isCurrentPathLeaf}
 		/>
 	) : (
 		<EmptyState

--- a/studio-ui/ui/app/src/components/BrowseFilesDialog/BrowseFilesDialogContainer.tsx
+++ b/studio-ui/ui/app/src/components/BrowseFilesDialog/BrowseFilesDialogContainer.tsx
@@ -24,14 +24,15 @@ import { useSpreadState } from '../../hooks/useSpreadState';
 import { useDispatch } from 'react-redux';
 import LookupTable from '../../models/LookupTable';
 import { BrowseFilesDialogUI, viewModes } from '.';
-import { BrowseFilesDialogContainerProps, initialParameters } from './utils';
+import { BrowseFilesDialogContainerProps, contentItemToMediaItem, initialParameters } from './utils';
 import { checkPathExistence } from '../../services/content';
 import { FormattedMessage } from 'react-intl';
 import EmptyState from '../EmptyState';
 import BrowseFilesDialogContainerSkeleton from './BrowseFilesDialogContainerSkeleton';
 import { getStoredBrowseDialogViewMode, setStoredBrowseDialogViewMode } from '../../utils/state';
 import useActiveUser from '../../hooks/useActiveUser';
-import { withIndex, withoutIndex } from '../../utils/path';
+import { withIndex, withoutIndex, isPagePath } from '../../utils/path';
+import { ContentItem } from '../../models/Item';
 import { MediaCardViewModes } from '../MediaCard';
 import { createPresenceTable } from '../../utils/array';
 import { createLookupTable } from '../../utils/object';
@@ -194,9 +195,20 @@ export function BrowseFilesDialogContainer(props: BrowseFilesDialogContainerProp
 		setSelectedLookup({ [path]: selected ? items.find((item) => item.path === path) : null });
 	};
 
-	const onPathSelected = (path: string) => {
-		setCurrentPath(withoutIndex(path));
+	const onPathSelected = (path: string, item?: ContentItem) => {
+		const nextPath = withoutIndex(path);
+		setCurrentPath(nextPath);
+
+		if (!multiSelect && item?.systemType === 'page' && item.childrenCount === 0) {
+			const mediaItem = items?.find((searchItem) => searchItem.path === item.path) ?? contentItemToMediaItem(item);
+			setSelectedCard(mediaItem);
+		} else if (!multiSelect) {
+			setSelectedCard(null);
+		}
 	};
+
+	const treeSelectedPath =
+		!multiSelect && selectedCard?.path && isPagePath(selectedCard.path) ? selectedCard.path : currentPath;
 
 	const onCloseButtonClick = (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => onClose(e, null);
 
@@ -266,6 +278,7 @@ export function BrowseFilesDialogContainer(props: BrowseFilesDialogContainerProp
 			handleSearchKeyword={handleSearchKeyword}
 			onCloseButtonClick={onCloseButtonClick}
 			onPathSelected={onPathSelected}
+			treeSelectedPath={treeSelectedPath}
 			onSelectButtonClick={onSelectButtonClick}
 			numOfLoaderItems={numOfLoaderItems}
 			onRefresh={onRefresh}

--- a/studio-ui/ui/app/src/components/BrowseFilesDialog/BrowseFilesDialogUI.tsx
+++ b/studio-ui/ui/app/src/components/BrowseFilesDialog/BrowseFilesDialogUI.tsx
@@ -80,6 +80,7 @@ export function BrowseFilesDialogUI(props: BrowseFilesDialogUIProps) {
 		onCheckboxChecked,
 		handleSearchKeyword,
 		onPathSelected,
+		treeSelectedPath,
 		onSelectButtonClick,
 		onChangePage,
 		onChangeRowsPerPage,
@@ -152,7 +153,11 @@ export function BrowseFilesDialogUI(props: BrowseFilesDialogUIProps) {
 								rowGap: '20px'
 							}}
 						>
-							<FolderBrowserTreeView rootPath={path} onPathSelected={onPathSelected} selectedPath={currentPath} />
+							<FolderBrowserTreeView
+								rootPath={path}
+								onPathSelected={onPathSelected}
+								selectedPath={treeSelectedPath}
+							/>
 						</Box>
 						<Box
 							onMouseDown={handleTreePanelResizeMouseDown}

--- a/studio-ui/ui/app/src/components/BrowseFilesDialog/BrowseFilesDialogUI.tsx
+++ b/studio-ui/ui/app/src/components/BrowseFilesDialog/BrowseFilesDialogUI.tsx
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useCallback, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import DialogBody from '../DialogBody/DialogBody';
 import DialogFooter from '../DialogFooter/DialogFooter';
 import SecondaryButton from '../SecondaryButton';
@@ -105,6 +105,7 @@ export function BrowseFilesDialogUI(props: BrowseFilesDialogUIProps) {
 	const [treePanelWidth, setTreePanelWidth] = useState(TREE_PANEL_DEFAULT_WIDTH);
 	const [treePanelResizeActive, setTreePanelResizeActive] = useState(false);
 	const treePanelRef = useRef<HTMLDivElement>(null);
+	const treePanelResizeListenersRef = useRef<{ mouseUp: () => void; blur: () => void } | null>(null);
 
 	const handleTreePanelMouseMove = useCallback((e: MouseEvent) => {
 		e.preventDefault();
@@ -117,16 +118,40 @@ export function BrowseFilesDialogUI(props: BrowseFilesDialogUIProps) {
 		setTreePanelWidth(newWidth);
 	}, []);
 
+	const cleanupTreePanelResize = useCallback(() => {
+		const listeners = treePanelResizeListenersRef.current;
+		if (!listeners) {
+			return;
+		}
+		treePanelResizeListenersRef.current = null;
+		setTreePanelResizeActive(false);
+		document.removeEventListener('mouseup', listeners.mouseUp, true);
+		document.removeEventListener('mousemove', handleTreePanelMouseMove, true);
+		window.removeEventListener('blur', listeners.blur);
+	}, [handleTreePanelMouseMove]);
+
+	useEffect(() => {
+		return () => {
+			cleanupTreePanelResize();
+		};
+	}, [cleanupTreePanelResize]);
+
 	const handleTreePanelResizeMouseDown = useCallback(() => {
+		if (treePanelResizeListenersRef.current) {
+			return;
+		}
 		setTreePanelResizeActive(true);
 		const handleMouseUp = () => {
-			setTreePanelResizeActive(false);
-			document.removeEventListener('mouseup', handleMouseUp, true);
-			document.removeEventListener('mousemove', handleTreePanelMouseMove, true);
+			cleanupTreePanelResize();
 		};
+		const handleBlur = () => {
+			cleanupTreePanelResize();
+		};
+		treePanelResizeListenersRef.current = { mouseUp: handleMouseUp, blur: handleBlur };
 		document.addEventListener('mouseup', handleMouseUp, true);
 		document.addEventListener('mousemove', handleTreePanelMouseMove, true);
-	}, [handleTreePanelMouseMove]);
+		window.addEventListener('blur', handleBlur);
+	}, [cleanupTreePanelResize, handleTreePanelMouseMove]);
 
 	return (
 		<>

--- a/studio-ui/ui/app/src/components/BrowseFilesDialog/BrowseFilesDialogUI.tsx
+++ b/studio-ui/ui/app/src/components/BrowseFilesDialog/BrowseFilesDialogUI.tsx
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, { useRef, useState } from 'react';
 import DialogBody from '../DialogBody/DialogBody';
 import DialogFooter from '../DialogFooter/DialogFooter';
 import SecondaryButton from '../SecondaryButton';
@@ -51,7 +51,7 @@ import GridViewIcon from '@mui/icons-material/GridOnRounded';
 import ReorderRoundedIcon from '@mui/icons-material/ReorderRounded';
 import { SORT_AUTO } from '../Search/utils';
 import Checkbox from '@mui/material/Checkbox';
-import palette from '../../styles/palette';
+import ResizeableDrawer from '../ResizeableDrawer/ResizeableDrawer';
 
 const TREE_PANEL_DEFAULT_WIDTH = 270;
 const TREE_PANEL_MIN_WIDTH = 240;
@@ -103,135 +103,48 @@ export function BrowseFilesDialogUI(props: BrowseFilesDialogUIProps) {
 	const [sortMenuOpen, setSortMenuOpen] = useState(false);
 	const buttonRef = useRef(undefined);
 	const [treePanelWidth, setTreePanelWidth] = useState(TREE_PANEL_DEFAULT_WIDTH);
-	const [treePanelResizeActive, setTreePanelResizeActive] = useState(false);
-	const treePanelRef = useRef<HTMLDivElement>(null);
-	const treePanelResizeListenersRef = useRef<{ mouseUp: () => void; blur: () => void } | null>(null);
-
-	const handleTreePanelMouseMove = useCallback((e: MouseEvent) => {
-		e.preventDefault();
-		if (!treePanelRef.current) {
-			return;
-		}
-		const left = treePanelRef.current.getBoundingClientRect().left;
-		let newWidth = e.clientX - left + 5;
-		newWidth = Math.min(TREE_PANEL_MAX_WIDTH, Math.max(TREE_PANEL_MIN_WIDTH, newWidth));
-		setTreePanelWidth(newWidth);
-	}, []);
-
-	const cleanupTreePanelResize = useCallback(() => {
-		const listeners = treePanelResizeListenersRef.current;
-		if (!listeners) {
-			return;
-		}
-		treePanelResizeListenersRef.current = null;
-		setTreePanelResizeActive(false);
-		document.removeEventListener('mouseup', listeners.mouseUp, true);
-		document.removeEventListener('mousemove', handleTreePanelMouseMove, true);
-		window.removeEventListener('blur', listeners.blur);
-	}, [handleTreePanelMouseMove]);
-
-	useEffect(() => {
-		return () => {
-			cleanupTreePanelResize();
-		};
-	}, [cleanupTreePanelResize]);
-
-	const handleTreePanelResizeMouseDown = useCallback(() => {
-		if (treePanelResizeListenersRef.current) {
-			return;
-		}
-		setTreePanelResizeActive(true);
-		const handleMouseUp = () => {
-			cleanupTreePanelResize();
-		};
-		const handleBlur = () => {
-			cleanupTreePanelResize();
-		};
-		treePanelResizeListenersRef.current = { mouseUp: handleMouseUp, blur: handleBlur };
-		document.addEventListener('mouseup', handleMouseUp, true);
-		document.addEventListener('mousemove', handleTreePanelMouseMove, true);
-		window.addEventListener('blur', handleBlur);
-	}, [cleanupTreePanelResize, handleTreePanelMouseMove]);
-
-	const handleTreePanelResizeKeyDown = useCallback((e: React.KeyboardEvent) => {
-		if (e.key !== 'ArrowLeft' && e.key !== 'ArrowRight') {
-			return;
-		}
-		e.preventDefault();
-		const delta = e.key === 'ArrowRight' ? 10 : -10;
-		setTreePanelWidth((prev) => Math.min(TREE_PANEL_MAX_WIDTH, Math.max(TREE_PANEL_MIN_WIDTH, prev + delta)));
-	}, []);
 
 	return (
 		<>
-			<DialogBody sx={{ minHeight: '60vh', padding: 0 }}>
-				<Box display="flex" sx={{ flex: 1, minHeight: '60vh', overflow: 'hidden' }}>
-					<Box
-						ref={treePanelRef}
-						sx={{
-							width: treePanelWidth,
-							minWidth: treePanelWidth,
-							flexShrink: 0,
-							position: 'relative',
-							display: 'flex',
-							flexDirection: 'column'
-						}}
-					>
-						<Box
-							display="flex"
-							flexDirection="column"
-							sx={{
-								flex: 1,
-								minHeight: 0,
-								padding: '16px',
-								overflow: 'auto',
-								rowGap: '20px'
-							}}
-						>
-							<FolderBrowserTreeView
-								rootPath={path}
-								onPathSelected={onPathSelected}
-								selectedPath={currentPath}
-								highlightedPath={treeSelectedPath}
-							/>
-						</Box>
-						<Box
-							onMouseDown={handleTreePanelResizeMouseDown}
-							onKeyDown={handleTreePanelResizeKeyDown}
-							role="separator"
-							tabIndex={0}
-							aria-orientation="vertical"
-							aria-label={formatMessage({ defaultMessage: 'Resize folder panel' })}
-							aria-valuemin={TREE_PANEL_MIN_WIDTH}
-							aria-valuemax={TREE_PANEL_MAX_WIDTH}
-							aria-valuenow={Math.round(treePanelWidth)}
-							sx={{
-								position: 'absolute',
-								top: 0,
-								bottom: 0,
-								right: 0,
-								width: '10px',
-								marginRight: '-5px',
-								cursor: 'ew-resize',
-								zIndex: 2,
-								display: 'flex',
-								justifyContent: 'center',
-								alignItems: 'stretch',
-								'&::before': {
-									content: '""',
-									display: 'block',
-									width: treePanelResizeActive ? '4px' : '2px',
-									backgroundColor: (theme) => (treePanelResizeActive ? palette.blue.tint : theme.palette.divider),
-									transition: 'width 200ms, background-color 200ms'
-								},
-								'&:hover::before': {
-									width: '4px',
-									backgroundColor: palette.blue.tint
-								}
-							}}
-						/>
-					</Box>
-					<Box component="section" sx={{ flexGrow: 1, minWidth: 0, padding: '16px', overflow: 'auto' }}>
+			<DialogBody sx={{ minHeight: '60vh', padding: 0, position: 'relative' }}>
+				<ResizeableDrawer
+					open
+					width={treePanelWidth}
+					minWidth={TREE_PANEL_MIN_WIDTH}
+					maxWidth={TREE_PANEL_MAX_WIDTH}
+					onWidthChange={setTreePanelWidth}
+					sxs={{
+						drawerPaper: {
+							position: 'absolute',
+							top: 0,
+							bottom: 0,
+							height: 'auto'
+						},
+						resizeHandle: { backgroundColor: 'transparent' },
+						drawerBody: {
+							padding: '16px',
+							overflowY: 'auto',
+							overflowX: 'hidden'
+						}
+					}}
+				>
+					<FolderBrowserTreeView
+						rootPath={path}
+						onPathSelected={onPathSelected}
+						selectedPath={currentPath}
+						highlightedPath={treeSelectedPath}
+					/>
+				</ResizeableDrawer>
+				<Box
+					component="section"
+					sx={{
+						marginLeft: `${treePanelWidth}px`,
+						minHeight: '60vh',
+						minWidth: 0,
+						padding: '16px',
+						overflow: 'auto'
+					}}
+				>
 						<Paper
 							sx={{
 								paddingLeft: (theme) => theme.spacing(1),
@@ -486,7 +399,6 @@ export function BrowseFilesDialogUI(props: BrowseFilesDialogUIProps) {
 								/>
 							))}
 					</Box>
-				</Box>
 			</DialogBody>
 			<DialogFooter>
 				<SecondaryButton onClick={onCloseButtonClick}>

--- a/studio-ui/ui/app/src/components/BrowseFilesDialog/BrowseFilesDialogUI.tsx
+++ b/studio-ui/ui/app/src/components/BrowseFilesDialog/BrowseFilesDialogUI.tsx
@@ -153,6 +153,15 @@ export function BrowseFilesDialogUI(props: BrowseFilesDialogUIProps) {
 		window.addEventListener('blur', handleBlur);
 	}, [cleanupTreePanelResize, handleTreePanelMouseMove]);
 
+	const handleTreePanelResizeKeyDown = useCallback((e: React.KeyboardEvent) => {
+		if (e.key !== 'ArrowLeft' && e.key !== 'ArrowRight') {
+			return;
+		}
+		e.preventDefault();
+		const delta = e.key === 'ArrowRight' ? 10 : -10;
+		setTreePanelWidth((prev) => Math.min(TREE_PANEL_MAX_WIDTH, Math.max(TREE_PANEL_MIN_WIDTH, prev + delta)));
+	}, []);
+
 	return (
 		<>
 			<DialogBody sx={{ minHeight: '60vh', padding: 0 }}>
@@ -188,9 +197,14 @@ export function BrowseFilesDialogUI(props: BrowseFilesDialogUIProps) {
 						</Box>
 						<Box
 							onMouseDown={handleTreePanelResizeMouseDown}
+							onKeyDown={handleTreePanelResizeKeyDown}
 							role="separator"
+							tabIndex={0}
 							aria-orientation="vertical"
 							aria-label={formatMessage({ defaultMessage: 'Resize folder panel' })}
+							aria-valuemin={TREE_PANEL_MIN_WIDTH}
+							aria-valuemax={TREE_PANEL_MAX_WIDTH}
+							aria-valuenow={Math.round(treePanelWidth)}
 							sx={{
 								position: 'absolute',
 								top: 0,

--- a/studio-ui/ui/app/src/components/BrowseFilesDialog/BrowseFilesDialogUI.tsx
+++ b/studio-ui/ui/app/src/components/BrowseFilesDialog/BrowseFilesDialogUI.tsx
@@ -95,7 +95,8 @@ export function BrowseFilesDialogUI(props: BrowseFilesDialogUIProps) {
 		disableSubmission,
 		allSelected,
 		someSelected,
-		onSelectAll
+		onSelectAll,
+		isCurrentPathLeaf
 	} = props;
 	// endregion
 	const { formatMessage } = useIntl();
@@ -432,12 +433,19 @@ export function BrowseFilesDialogUI(props: BrowseFilesDialogUIProps) {
 									})
 								: new Array(numOfLoaderItems).fill(null).map((x, i) => <MediaSkeletonCard key={i} />)}
 						</Box>
-						{items && items.length === 0 && (
-							<EmptyState
-								sxs={{ root: { flexGrow: 1 } }}
-								title={<FormattedMessage id="browseFilesDialog.noResults" defaultMessage="No items found." />}
-							/>
-						)}
+						{items &&
+							items.length === 0 &&
+							(isCurrentPathLeaf ? (
+								<EmptyState
+									sxs={{ root: { flexGrow: 1 } }}
+									title={<FormattedMessage defaultMessage="This item has no children." />}
+								/>
+							) : (
+								<EmptyState
+									sxs={{ root: { flexGrow: 1 } }}
+									title={<FormattedMessage id="browseFilesDialog.noResults" defaultMessage="No items found." />}
+								/>
+							))}
 					</Box>
 				</Box>
 			</DialogBody>

--- a/studio-ui/ui/app/src/components/BrowseFilesDialog/BrowseFilesDialogUI.tsx
+++ b/studio-ui/ui/app/src/components/BrowseFilesDialog/BrowseFilesDialogUI.tsx
@@ -156,7 +156,8 @@ export function BrowseFilesDialogUI(props: BrowseFilesDialogUIProps) {
 							<FolderBrowserTreeView
 								rootPath={path}
 								onPathSelected={onPathSelected}
-								selectedPath={treeSelectedPath}
+								selectedPath={currentPath}
+								highlightedPath={treeSelectedPath}
 							/>
 						</Box>
 						<Box

--- a/studio-ui/ui/app/src/components/BrowseFilesDialog/BrowseFilesDialogUI.tsx
+++ b/studio-ui/ui/app/src/components/BrowseFilesDialog/BrowseFilesDialogUI.tsx
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useRef, useState } from 'react';
+import React, { useCallback, useRef, useState } from 'react';
 import DialogBody from '../DialogBody/DialogBody';
 import DialogFooter from '../DialogFooter/DialogFooter';
 import SecondaryButton from '../SecondaryButton';
@@ -51,6 +51,11 @@ import GridViewIcon from '@mui/icons-material/GridOnRounded';
 import ReorderRoundedIcon from '@mui/icons-material/ReorderRounded';
 import { SORT_AUTO } from '../Search/utils';
 import Checkbox from '@mui/material/Checkbox';
+import palette from '../../styles/palette';
+
+const TREE_PANEL_DEFAULT_WIDTH = 270;
+const TREE_PANEL_MIN_WIDTH = 240;
+const TREE_PANEL_MAX_WIDTH = 480;
 
 export function BrowseFilesDialogUI(props: BrowseFilesDialogUIProps) {
 	// region const { ... } = props;
@@ -95,26 +100,92 @@ export function BrowseFilesDialogUI(props: BrowseFilesDialogUIProps) {
 	const { formatMessage } = useIntl();
 	const [sortMenuOpen, setSortMenuOpen] = useState(false);
 	const buttonRef = useRef(undefined);
+	const [treePanelWidth, setTreePanelWidth] = useState(TREE_PANEL_DEFAULT_WIDTH);
+	const [treePanelResizeActive, setTreePanelResizeActive] = useState(false);
+	const treePanelRef = useRef<HTMLDivElement>(null);
+
+	const handleTreePanelMouseMove = useCallback((e: MouseEvent) => {
+		e.preventDefault();
+		if (!treePanelRef.current) {
+			return;
+		}
+		const left = treePanelRef.current.getBoundingClientRect().left;
+		let newWidth = e.clientX - left + 5;
+		newWidth = Math.min(TREE_PANEL_MAX_WIDTH, Math.max(TREE_PANEL_MIN_WIDTH, newWidth));
+		setTreePanelWidth(newWidth);
+	}, []);
+
+	const handleTreePanelResizeMouseDown = useCallback(() => {
+		setTreePanelResizeActive(true);
+		const handleMouseUp = () => {
+			setTreePanelResizeActive(false);
+			document.removeEventListener('mouseup', handleMouseUp, true);
+			document.removeEventListener('mousemove', handleTreePanelMouseMove, true);
+		};
+		document.addEventListener('mouseup', handleMouseUp, true);
+		document.addEventListener('mousemove', handleTreePanelMouseMove, true);
+	}, [handleTreePanelMouseMove]);
 
 	return (
 		<>
 			<DialogBody sx={{ minHeight: '60vh', padding: 0 }}>
-				<Box display="flex" sx={{ overflow: 'hidden' }}>
+				<Box display="flex" sx={{ flex: 1, minHeight: '60vh', overflow: 'hidden' }}>
 					<Box
+						ref={treePanelRef}
 						sx={{
-							width: '270px',
-							minWidth: '270px',
-							padding: '16px',
-							overflow: 'auto',
-							rowGap: (theme) => theme.spacing(1)
+							width: treePanelWidth,
+							minWidth: treePanelWidth,
+							flexShrink: 0,
+							position: 'relative',
+							display: 'flex',
+							flexDirection: 'column'
 						}}
-						display="flex"
-						flexDirection="column"
-						rowGap="20px"
 					>
-						<FolderBrowserTreeView rootPath={path} onPathSelected={onPathSelected} selectedPath={currentPath} />
+						<Box
+							display="flex"
+							flexDirection="column"
+							sx={{
+								flex: 1,
+								minHeight: 0,
+								padding: '16px',
+								overflow: 'auto',
+								rowGap: '20px'
+							}}
+						>
+							<FolderBrowserTreeView rootPath={path} onPathSelected={onPathSelected} selectedPath={currentPath} />
+						</Box>
+						<Box
+							onMouseDown={handleTreePanelResizeMouseDown}
+							role="separator"
+							aria-orientation="vertical"
+							aria-label={formatMessage({ defaultMessage: 'Resize folder panel' })}
+							sx={{
+								position: 'absolute',
+								top: 0,
+								bottom: 0,
+								right: 0,
+								width: '10px',
+								marginRight: '-5px',
+								cursor: 'ew-resize',
+								zIndex: 2,
+								display: 'flex',
+								justifyContent: 'center',
+								alignItems: 'stretch',
+								'&::before': {
+									content: '""',
+									display: 'block',
+									width: treePanelResizeActive ? '4px' : '2px',
+									backgroundColor: (theme) => (treePanelResizeActive ? palette.blue.tint : theme.palette.divider),
+									transition: 'width 200ms, background-color 200ms'
+								},
+								'&:hover::before': {
+									width: '4px',
+									backgroundColor: palette.blue.tint
+								}
+							}}
+						/>
 					</Box>
-					<Box component="section" sx={{ flexGrow: 1, padding: '16px', overflow: 'auto' }}>
+					<Box component="section" sx={{ flexGrow: 1, minWidth: 0, padding: '16px', overflow: 'auto' }}>
 						<Paper
 							sx={{
 								paddingLeft: (theme) => theme.spacing(1),

--- a/studio-ui/ui/app/src/components/BrowseFilesDialog/utils.ts
+++ b/studio-ui/ui/app/src/components/BrowseFilesDialog/utils.ts
@@ -72,6 +72,7 @@ export interface BrowseFilesDialogUIProps {
 	disableSubmission?: boolean;
 	allSelected: boolean;
 	someSelected: boolean;
+	isCurrentPathLeaf: boolean;
 	onCardSelected(item: MediaItem): void;
 	onPreviewImage?(item: MediaItem): void;
 	onCheckboxChecked(path: string, selected: boolean): void;

--- a/studio-ui/ui/app/src/components/BrowseFilesDialog/utils.ts
+++ b/studio-ui/ui/app/src/components/BrowseFilesDialog/utils.ts
@@ -15,6 +15,7 @@
  */
 
 import { ElasticParams, MediaItem, SearchItem } from '../../models/Search';
+import { ContentItem } from '../../models/Item';
 import StandardAction from '../../models/StandardAction';
 import { EnhancedDialogProps } from '../EnhancedDialog';
 import React from 'react';
@@ -75,7 +76,8 @@ export interface BrowseFilesDialogUIProps {
 	onPreviewImage?(item: MediaItem): void;
 	onCheckboxChecked(path: string, selected: boolean): void;
 	handleSearchKeyword(keyword: string): void;
-	onPathSelected(path: string): void;
+	onPathSelected(path: string, item?: ContentItem): void;
+	treeSelectedPath: string;
 	onSelectButtonClick(): void;
 	onChangePage(page: number): void;
 	onChangeRowsPerPage(event): void;
@@ -97,3 +99,17 @@ export const initialParameters: ElasticParams = {
 };
 
 export const viewModes: MediaCardViewModes[] = ['card', 'compact', 'row'];
+
+export function contentItemToMediaItem(item: ContentItem): MediaItem {
+	return {
+		path: item.path,
+		name: item.label,
+		type: item.contentTypeId,
+		mimeType: item.mimeType ?? '',
+		previewUrl: item.previewUrl ?? '',
+		lastModifier: item.modifier?.username ?? '',
+		lastModified: item.dateModified ?? '',
+		size: 0,
+		snippets: ''
+	};
+}

--- a/studio-ui/ui/app/src/components/FolderBrowserTreeView/FolderBrowserTreeView.tsx
+++ b/studio-ui/ui/app/src/components/FolderBrowserTreeView/FolderBrowserTreeView.tsx
@@ -23,6 +23,9 @@ import useActiveUser from '../../hooks/useActiveUser';
 import { useDispatch } from 'react-redux';
 import { pathNavigatorTreeExpandPath, pathNavigatorTreeFetchPathChildren } from '../../state/actions/pathNavigatorTree';
 import { getIndividualPaths, withIndex } from '../../utils/path';
+import { useItemsByPath } from '../../hooks/useItemsByPath';
+import { lookupItemByPath } from '../../utils/content';
+import { ContentItem } from '../../models/Item';
 import { forkJoin, of } from 'rxjs';
 import { batchActions } from '../../state/actions/misc';
 import useSelection from '../../hooks/useSelection';
@@ -32,7 +35,7 @@ import { useIntl } from 'react-intl';
 export interface FolderBrowserTreeViewProps {
 	rootPath: string;
 	selectedPath: string;
-	onPathSelected(path: string): void;
+	onPathSelected(path: string, item?: ContentItem): void;
 }
 
 export function FolderBrowserTreeView(props: FolderBrowserTreeViewProps) {
@@ -43,6 +46,7 @@ export function FolderBrowserTreeView(props: FolderBrowserTreeViewProps) {
 	const { uuid, id: siteId } = useActiveSite();
 	const { username } = useActiveUser();
 	const dispatch = useDispatch();
+	const itemsByPath = useItemsByPath();
 	const selectedPathWithIndex = withIndex(selectedPath);
 	const refs = useUpdateRefs({ tree });
 	useEffect(() => {
@@ -94,7 +98,7 @@ export function FolderBrowserTreeView(props: FolderBrowserTreeViewProps) {
 			initialCollapsed={false}
 			initialSystemTypes={['folder', 'page']}
 			active={{ [selectedPathWithIndex in (tree?.totalByPath ?? {}) ? selectedPathWithIndex : selectedPath]: true }}
-			onNodeClick={(e, path) => onPathSelected?.(path)}
+			onNodeClick={(e, path) => onPathSelected?.(path, lookupItemByPath(path, itemsByPath))}
 			sxs={{
 				header: { '.MuiTypography-root': { fontWeight: 'bold' } }
 			}}

--- a/studio-ui/ui/app/src/components/FolderBrowserTreeView/FolderBrowserTreeView.tsx
+++ b/studio-ui/ui/app/src/components/FolderBrowserTreeView/FolderBrowserTreeView.tsx
@@ -15,7 +15,7 @@
  */
 
 // @ts-ignore - React typings haven't been updated to include react 18 hooks
-import React, { useCallback, useEffect, useId } from 'react';
+import React, { useCallback, useEffect, useId, useRef } from 'react';
 import useActiveSite from '../../hooks/useActiveSite';
 import { PathNavigatorTree } from '../PathNavigatorTree';
 import { removeStoredPathNavigatorTree } from '../../utils/state';
@@ -44,6 +44,7 @@ export function FolderBrowserTreeView(props: FolderBrowserTreeViewProps) {
 	const { username } = useActiveUser();
 	const dispatch = useDispatch();
 	const selectedPathWithIndex = withIndex(selectedPath);
+	const pendingChildFetchPathsRef = useRef<Set<string>>(new Set());
 	const refs = useUpdateRefs({ tree });
 	useEffect(() => {
 		if (
@@ -84,22 +85,31 @@ export function FolderBrowserTreeView(props: FolderBrowserTreeViewProps) {
 				return;
 			}
 			const withIndexXml = withIndex(path);
-			if (tree.expanded.includes(path) || tree.expanded.includes(withIndexXml)) {
-				return;
-			}
+			const isExpanded = tree.expanded.includes(path) || tree.expanded.includes(withIndexXml);
 			const childCount = tree.totalByPath[path] ?? tree.totalByPath[withIndexXml] ?? 0;
 			if (childCount <= 0) {
 				return;
 			}
 			const childrenLoaded = path in tree.childrenByParentPath || withIndexXml in tree.childrenByParentPath;
-			dispatch(
-				childrenLoaded
-					? pathNavigatorTreeExpandPath({
+			if (childrenLoaded) {
+				if (!isExpanded) {
+					dispatch(
+						pathNavigatorTreeExpandPath({
 							id,
 							path: withIndexXml in tree.childrenByParentPath ? withIndexXml : path
 						})
-					: pathNavigatorTreeFetchPathChildren({ id, path, expand: true })
-			);
+					);
+				}
+				return;
+			}
+			if (tree.errorByPath[path]) {
+				pendingChildFetchPathsRef.current.delete(path);
+			}
+			if (isExpanded || pendingChildFetchPathsRef.current.has(path)) {
+				return;
+			}
+			pendingChildFetchPathsRef.current.add(path);
+			dispatch(pathNavigatorTreeFetchPathChildren({ id, path, expand: true }));
 		},
 		[dispatch, id, onPathSelected, tree]
 	);

--- a/studio-ui/ui/app/src/components/FolderBrowserTreeView/FolderBrowserTreeView.tsx
+++ b/studio-ui/ui/app/src/components/FolderBrowserTreeView/FolderBrowserTreeView.tsx
@@ -102,10 +102,11 @@ export function FolderBrowserTreeView(props: FolderBrowserTreeViewProps) {
 				}
 				return;
 			}
-			if (tree.errorByPath[path]) {
+			const fetchError = tree.errorByPath[path];
+			if (fetchError) {
 				pendingChildFetchPathsRef.current.delete(path);
 			}
-			if (isExpanded || pendingChildFetchPathsRef.current.has(path)) {
+			if ((!fetchError && isExpanded) || pendingChildFetchPathsRef.current.has(path)) {
 				return;
 			}
 			pendingChildFetchPathsRef.current.add(path);

--- a/studio-ui/ui/app/src/components/FolderBrowserTreeView/FolderBrowserTreeView.tsx
+++ b/studio-ui/ui/app/src/components/FolderBrowserTreeView/FolderBrowserTreeView.tsx
@@ -15,7 +15,7 @@
  */
 
 // @ts-ignore - React typings haven't been updated to include react 18 hooks
-import React, { useEffect, useId } from 'react';
+import React, { useCallback, useEffect, useId } from 'react';
 import useActiveSite from '../../hooks/useActiveSite';
 import { PathNavigatorTree } from '../PathNavigatorTree';
 import { removeStoredPathNavigatorTree } from '../../utils/state';
@@ -23,7 +23,6 @@ import useActiveUser from '../../hooks/useActiveUser';
 import { useDispatch } from 'react-redux';
 import { pathNavigatorTreeExpandPath, pathNavigatorTreeFetchPathChildren } from '../../state/actions/pathNavigatorTree';
 import { getIndividualPaths, withIndex } from '../../utils/path';
-import { forkJoin, of } from 'rxjs';
 import { batchActions } from '../../state/actions/misc';
 import useSelection from '../../hooks/useSelection';
 import useUpdateRefs from '../../hooks/useUpdateRefs';
@@ -52,33 +51,24 @@ export function FolderBrowserTreeView(props: FolderBrowserTreeViewProps) {
 			// avoid changes on its state to trigger this effect unnecessarily.
 			tree?.id === id
 		) {
+			const chunk = refs.current.tree;
 			const path = selectedPath || rootPath;
-			// If it's `/site/website/*`, there's possibility of `index.xml` behaviours
-			if (path.startsWith('/site/website')) {
-				const paths = getIndividualPaths(path, rootPath);
-				forkJoin(
-					paths.map((p) => {
+			const actions = path.startsWith('/site/website')
+				? getIndividualPaths(path, rootPath).map((p) => {
 						const withIndexXml = withIndex(p);
-						return withIndexXml in refs.current.tree.childrenByParentPath || p in refs.current.tree.childrenByParentPath
-							? of(
-									pathNavigatorTreeExpandPath({
-										id,
-										path: withIndexXml in refs.current.tree.childrenByParentPath ? withIndexXml : p
-									})
-								)
-							: of(pathNavigatorTreeFetchPathChildren({ id, path: p, expand: true }));
+						return withIndexXml in chunk.childrenByParentPath || p in chunk.childrenByParentPath
+							? pathNavigatorTreeExpandPath({
+									id,
+									path: withIndexXml in chunk.childrenByParentPath ? withIndexXml : p
+								})
+							: pathNavigatorTreeFetchPathChildren({ id, path: p, expand: true });
 					})
-				).subscribe((actions) => {
-					dispatch(actions.length === 1 ? actions[0] : batchActions(actions));
-				});
-			} else {
-				const actions = getIndividualPaths(path, rootPath).map((p) =>
-					p in refs.current.tree.childrenByParentPath
-						? pathNavigatorTreeExpandPath({ id, path: p })
-						: pathNavigatorTreeFetchPathChildren({ id, path: p, expand: true })
-				);
-				actions.length && dispatch(actions.length === 1 ? actions[0] : batchActions(actions));
-			}
+				: getIndividualPaths(path, rootPath).map((p) =>
+						p in chunk.childrenByParentPath
+							? pathNavigatorTreeExpandPath({ id, path: p })
+							: pathNavigatorTreeFetchPathChildren({ id, path: p, expand: true })
+					);
+			actions.length && dispatch(actions.length === 1 ? actions[0] : batchActions(actions));
 		}
 	}, [refs, dispatch, id, rootPath, selectedPath, siteId, tree?.id]);
 	useEffect(() => {
@@ -86,6 +76,34 @@ export function FolderBrowserTreeView(props: FolderBrowserTreeViewProps) {
 			removeStoredPathNavigatorTree(uuid, username, id);
 		};
 	}, [id, uuid, username]);
+
+	const handleNodeClick = useCallback(
+		(event: React.MouseEvent, path: string) => {
+			onPathSelected?.(path);
+			if (tree?.id !== id) {
+				return;
+			}
+			const withIndexXml = withIndex(path);
+			if (tree.expanded.includes(path) || tree.expanded.includes(withIndexXml)) {
+				return;
+			}
+			const childCount = tree.totalByPath[path] ?? tree.totalByPath[withIndexXml] ?? 0;
+			if (childCount <= 0) {
+				return;
+			}
+			const childrenLoaded = path in tree.childrenByParentPath || withIndexXml in tree.childrenByParentPath;
+			dispatch(
+				childrenLoaded
+					? pathNavigatorTreeExpandPath({
+							id,
+							path: withIndexXml in tree.childrenByParentPath ? withIndexXml : path
+						})
+					: pathNavigatorTreeFetchPathChildren({ id, path, expand: true })
+			);
+		},
+		[dispatch, id, onPathSelected, tree]
+	);
+
 	return (
 		<PathNavigatorTree
 			id={id}
@@ -95,7 +113,7 @@ export function FolderBrowserTreeView(props: FolderBrowserTreeViewProps) {
 			initialCollapsed={false}
 			initialSystemTypes={['folder', 'page']}
 			active={{ [selectedPathWithIndex in (tree?.totalByPath ?? {}) ? selectedPathWithIndex : selectedPath]: true }}
-			onNodeClick={(e, path) => onPathSelected?.(path)}
+			onNodeClick={handleNodeClick}
 			sxs={{
 				header: { '.MuiTypography-root': { fontWeight: 'bold' } },
 				activeItem:

--- a/studio-ui/ui/app/src/components/FolderBrowserTreeView/FolderBrowserTreeView.tsx
+++ b/studio-ui/ui/app/src/components/FolderBrowserTreeView/FolderBrowserTreeView.tsx
@@ -23,9 +23,6 @@ import useActiveUser from '../../hooks/useActiveUser';
 import { useDispatch } from 'react-redux';
 import { pathNavigatorTreeExpandPath, pathNavigatorTreeFetchPathChildren } from '../../state/actions/pathNavigatorTree';
 import { getIndividualPaths, withIndex } from '../../utils/path';
-import { useItemsByPath } from '../../hooks/useItemsByPath';
-import { lookupItemByPath } from '../../utils/content';
-import { ContentItem } from '../../models/Item';
 import { forkJoin, of } from 'rxjs';
 import { batchActions } from '../../state/actions/misc';
 import useSelection from '../../hooks/useSelection';
@@ -35,18 +32,18 @@ import { useIntl } from 'react-intl';
 export interface FolderBrowserTreeViewProps {
 	rootPath: string;
 	selectedPath: string;
-	onPathSelected(path: string, item?: ContentItem): void;
+	highlightedPath?: string;
+	onPathSelected(path: string): void;
 }
 
 export function FolderBrowserTreeView(props: FolderBrowserTreeViewProps) {
-	const { rootPath, selectedPath, onPathSelected } = props;
+	const { rootPath, selectedPath, highlightedPath, onPathSelected } = props;
 	const { formatMessage } = useIntl();
 	const id = useId();
 	const tree = useSelection((state) => state.pathNavigatorTree[id]);
 	const { uuid, id: siteId } = useActiveSite();
 	const { username } = useActiveUser();
 	const dispatch = useDispatch();
-	const itemsByPath = useItemsByPath();
 	const selectedPathWithIndex = withIndex(selectedPath);
 	const refs = useUpdateRefs({ tree });
 	useEffect(() => {
@@ -98,9 +95,13 @@ export function FolderBrowserTreeView(props: FolderBrowserTreeViewProps) {
 			initialCollapsed={false}
 			initialSystemTypes={['folder', 'page']}
 			active={{ [selectedPathWithIndex in (tree?.totalByPath ?? {}) ? selectedPathWithIndex : selectedPath]: true }}
-			onNodeClick={(e, path) => onPathSelected?.(path, lookupItemByPath(path, itemsByPath))}
+			onNodeClick={(e, path) => onPathSelected?.(path)}
 			sxs={{
-				header: { '.MuiTypography-root': { fontWeight: 'bold' } }
+				header: { '.MuiTypography-root': { fontWeight: 'bold' } },
+				activeItem:
+					selectedPath === highlightedPath
+						? { boxShadow: (theme) => `0px 0px 2px 2px ${theme.palette.primary.main}`, borderRadius: '2px' }
+						: {}
 			}}
 			showNavigableAsLinks={false}
 			showPublishingTarget={false}

--- a/studio-ui/ui/app/src/components/PathNavigatorTree/PathNavigatorTree.tsx
+++ b/studio-ui/ui/app/src/components/PathNavigatorTree/PathNavigatorTree.tsx
@@ -66,11 +66,10 @@ import usePossibleTranslation from '../../hooks/usePossibleTranslation';
 import TranslationOrText from '../../models/TranslationOrText';
 import { useIntl } from 'react-intl';
 
-export interface PathNavigatorTreeProps
-	extends Pick<
-		PathNavigatorTreeItemProps,
-		'showNavigableAsLinks' | 'showPublishingTarget' | 'showWorkflowState' | 'showItemMenu'
-	> {
+export interface PathNavigatorTreeProps extends Pick<
+	PathNavigatorTreeItemProps,
+	'showNavigableAsLinks' | 'showPublishingTarget' | 'showWorkflowState' | 'showItemMenu'
+> {
 	id: string;
 	label: TranslationOrText;
 	rootPath: string;
@@ -89,7 +88,7 @@ export interface PathNavigatorTreeProps
 	onNodeClick?: PathNavigatorTreeUIProps['onLabelClick'];
 	active?: PathNavigatorTreeItemProps['active'];
 	classes?: Partial<Record<'header', string>>;
-	sxs?: PartialSxRecord<'header'>;
+	sxs?: PartialSxRecord<'header' | 'activeItem'>;
 }
 
 export interface PathNavigatorTreeStateProps {
@@ -353,7 +352,7 @@ export function PathNavigatorTree(props: PathNavigatorTreeProps) {
 		<>
 			<PathNavigatorTreeUI
 				classes={{ header: classes?.header }}
-				sxs={{ header: sxs?.header }}
+				sxs={{ header: sxs?.header, activeItem: sxs?.activeItem }}
 				title={translatedLabel}
 				active={active}
 				icon={expandedIcon && collapsedIcon ? (state.collapsed ? collapsedIcon : expandedIcon) : icon}

--- a/studio-ui/ui/app/src/components/PathNavigatorTree/PathNavigatorTreeItem.tsx
+++ b/studio-ui/ui/app/src/components/PathNavigatorTree/PathNavigatorTreeItem.tsx
@@ -59,6 +59,7 @@ export interface PathNavigatorTreeItemProps extends Pick<
 }
 
 export type PathNavigatorTreeBreadcrumbsClassKey =
+	| 'activeItem'
 	| 'searchRoot'
 	| 'searchInput'
 	| 'searchCleanButton'
@@ -148,6 +149,7 @@ export function PathNavigatorTreeItem(props: PathNavigatorTreeItemProps) {
 				childrenByParentPath={childrenByParentPath}
 				errorByPath={errorByPath}
 				active={active}
+				sxs={sxs}
 				onLabelClick={onLabelClick}
 				onIconClick={onIconClick}
 				onOpenItemMenu={onOpenItemMenu}
@@ -447,7 +449,12 @@ export function PathNavigatorTreeItem(props: PathNavigatorTreeItemProps) {
 					}
 				},
 				[`& > .${treeItemClasses.content} > .${treeItemClasses.label}`]: {
-					...(active[path] ? { backgroundColor: (theme) => theme.palette.action.selected } : {})
+					...(active[path]
+						? {
+								backgroundColor: (theme) => theme.palette.action.selected,
+								...sxs?.activeItem
+							}
+						: {})
 				},
 				[`& .${treeItemClasses.iconContainer}`]: {
 					width: '26px',

--- a/studio-ui/ui/app/src/components/PathNavigatorTree/PathNavigatorTreeUI.tsx
+++ b/studio-ui/ui/app/src/components/PathNavigatorTree/PathNavigatorTreeUI.tsx
@@ -29,7 +29,7 @@ import { ErrorState } from '../ErrorState';
 import { SimpleTreeView } from '@mui/x-tree-view';
 import { PartialSxRecord } from '../../models';
 
-export type PathNavigatorTreeUIClassKey = 'root' | 'body' | 'header';
+export type PathNavigatorTreeUIClassKey = 'root' | 'body' | 'header' | 'activeItem';
 
 export interface PathNavigatorTreeUIProps
 	extends Pick<
@@ -145,6 +145,7 @@ export function PathNavigatorTreeUI(props: PathNavigatorTreeUIProps) {
 						<PathNavigatorTreeItem
 							path={rootPath}
 							active={active}
+							sxs={{ activeItem: sxs?.activeItem }}
 							itemsByPath={itemsByPath}
 							keywordByPath={keywordByPath}
 							totalByPath={totalByPath}


### PR DESCRIPTION
https://github.com/craftersoftware/craftercms/issues/8824

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a resizable folder tree panel in the Browse Files dialog (drawer-style layout with adjustable width).
- **Bug Fixes**
  - Improved folder-tree node selection so clicked paths resolve correctly and keep folder/page/media selection in sync for both single- and multi-select, with special handling for leaf pages.
  - Prevented redundant child-loading and improved error recovery during tree expansion.
- **UI Improvements**
  - Enhanced active-path highlighting with themeable “activeItem” styling across the path navigator.
  - Updated empty-state messaging to show “This item has no children.” when the current selection is a leaf page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->