### PR TITLE
[8844] FE2 - back to top button not working

### DIFF
--- a/studio-ui/ui/app/src/components/FormsEngine/FormsEngine.tsx
+++ b/studio-ui/ui/app/src/components/FormsEngine/FormsEngine.tsx
@@ -1013,7 +1013,7 @@ function FormOrchestrator(props: FormsEngineProps) {
 							))
 						)}
 						{/* Spacer & back to top */}
-						<FormBackToTop containerRef={containerRef} />
+						<FormBackToTop containerRef={containerRef} getScrollContainer={getScrollContainer} />
 					</Grid>
 					<Grid size="grow">
 						<StickyBox className="space-y" sx={{ height: 'auto' }}>

--- a/studio-ui/ui/app/src/components/FormsEngine/FormsEngine.tsx
+++ b/studio-ui/ui/app/src/components/FormsEngine/FormsEngine.tsx
@@ -772,12 +772,13 @@ function FormOrchestrator(props: FormsEngineProps) {
 
 	const handleOpenDrawerSidebar = () => {
 		const scroller = getScrollContainer(containerRef.current);
-		scroller.style.setProperty('--scroll-top', `${containerRef.current.scrollTop}px`);
+		scroller.style.setProperty('--scroll-top', `${scroller.scrollTop}px`);
 		scroller.style.overflowY = 'hidden';
 		setOpenDrawerSidebar(true);
 	};
 	const handleCloseDrawerSidebar: DrawerProps['onClose'] = () => {
-		containerRef.current.style.overflowY = '';
+		const scroller = getScrollContainer(containerRef.current);
+		scroller.style.overflowY = '';
 		setOpenDrawerSidebar(false);
 	};
 	const handleCloseDrawerForm: DrawerProps['onClose'] = () => {

--- a/studio-ui/ui/app/src/components/FormsEngine/components/FormBackToTop.tsx
+++ b/studio-ui/ui/app/src/components/FormsEngine/components/FormBackToTop.tsx
@@ -20,17 +20,19 @@ import Fab from '@mui/material/Fab';
 import { ArrowUpward } from '@mui/icons-material';
 import Box from '@mui/material/Box';
 import React, { RefObject } from 'react';
+import { getScrollContainer } from '../lib/formUtils';
 
 interface FormBackToTopProps {
 	containerRef: RefObject<HTMLElement>;
-	getScrollContainer?: (element: HTMLElement) => HTMLElement;
 }
 
-export function FormBackToTop({ containerRef, getScrollContainer = (e) => e }: FormBackToTopProps) {
+export function FormBackToTop({ containerRef }: FormBackToTopProps) {
 	return (
 		<Box minHeight={100} justifyContent="center" alignItems="center" display="flex">
 			<Tooltip title={<FormattedMessage defaultMessage="Back to top" />}>
-				<Fab onClick={() => getScrollContainer(containerRef.current).scroll({ top: 0, behavior: 'smooth' })}>
+				<Fab
+					onClick={() => getScrollContainer(containerRef.current).scroll({ top: 0, behavior: 'smooth' })}
+				>
 					<ArrowUpward />
 				</Fab>
 			</Tooltip>

--- a/studio-ui/ui/app/src/components/FormsEngine/components/FormBackToTop.tsx
+++ b/studio-ui/ui/app/src/components/FormsEngine/components/FormBackToTop.tsx
@@ -20,19 +20,17 @@ import Fab from '@mui/material/Fab';
 import { ArrowUpward } from '@mui/icons-material';
 import Box from '@mui/material/Box';
 import React, { RefObject } from 'react';
-import { getScrollContainer } from '../lib/formUtils';
 
 interface FormBackToTopProps {
 	containerRef: RefObject<HTMLElement>;
+	getScrollContainer?: (element: HTMLElement) => HTMLElement;
 }
 
-export function FormBackToTop({ containerRef }: FormBackToTopProps) {
+export function FormBackToTop({ containerRef, getScrollContainer = (e) => e }: FormBackToTopProps) {
 	return (
 		<Box minHeight={100} justifyContent="center" alignItems="center" display="flex">
 			<Tooltip title={<FormattedMessage defaultMessage="Back to top" />}>
-				<Fab
-					onClick={() => getScrollContainer(containerRef.current).scroll({ top: 0, behavior: 'smooth' })}
-				>
+				<Fab onClick={() => getScrollContainer(containerRef.current).scroll({ top: 0, behavior: 'smooth' })}>
 					<ArrowUpward />
 				</Fab>
 			</Tooltip>

--- a/studio-ui/ui/app/src/components/FormsEngine/components/FormLayout.tsx
+++ b/studio-ui/ui/app/src/components/FormsEngine/components/FormLayout.tsx
@@ -169,6 +169,7 @@ export const FormLayout = forwardRef<HTMLDivElement, FormLayoutProps>(function (
 			</Paper>
 			<Box
 				ref={mainContentRefCallback}
+				data-area-id="formMainContent"
 				sx={{
 					// TODO: Tabs will be done at a later phase.
 					// display: activeTab === 0 ? 'inherit' : 'none',

--- a/studio-ui/ui/app/src/components/FormsEngine/lib/formUtils.tsx
+++ b/studio-ui/ui/app/src/components/FormsEngine/lib/formUtils.tsx
@@ -80,12 +80,9 @@ import { ensureSingleSlash } from '../../../utils/string';
 import { isPagePath } from '../../../utils/path';
 import { nou } from '../../../utils/object';
 
-/**
- * Returns the scroll container for the form's container.
- * TODO: After much tweaking and testing, managed to get the form container box itself to be the scrolling element. Asses removal.
- **/
 export function getScrollContainer(container: HTMLElement): HTMLElement {
-	return container;
+	const mainContent = container.querySelector('[data-area-id="formMainContent"]');
+	return mainContent instanceof HTMLElement ? mainContent : container;
 }
 
 /**

--- a/studio-ui/ui/app/src/components/FormsEngine/lib/formUtils.tsx
+++ b/studio-ui/ui/app/src/components/FormsEngine/lib/formUtils.tsx
@@ -80,6 +80,9 @@ import { ensureSingleSlash } from '../../../utils/string';
 import { isPagePath } from '../../../utils/path';
 import { nou } from '../../../utils/object';
 
+/**
+ * Returns the scroll container for the form's container.
+ **/
 export function getScrollContainer(container: HTMLElement): HTMLElement {
 	const mainContent = container.querySelector('[data-area-id="formMainContent"]');
 	return mainContent instanceof HTMLElement ? mainContent : container;


### PR DESCRIPTION
https://github.com/craftersoftware/craftercms/issues/8844

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved “Back to top” navigation in forms by targeting the form’s main scrolling area.
  - Ensured scrolling behavior falls back safely when the dedicated form content area is unavailable.
  - Improved form drawer opening and closing behavior by applying scroll position and overflow changes to the correct content area.
  - Preserved reliable scrolling behavior across forms, including layouts where the main content area cannot be identified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->