### PR TITLE
[7231] Override default duplicate file handling in UploadDialogContainer

### DIFF
--- a/studio-ui/ui/app/src/components/UploadDialog/UploadDialogContainer.tsx
+++ b/studio-ui/ui/app/src/components/UploadDialog/UploadDialogContainer.tsx
@@ -117,6 +117,11 @@ export function UploadDialogContainer(props: UploadDialogContainerProps) {
 			locale: {
 				strings: { noDuplicates: formatMessage(translations.noDuplicates) },
 				pluralize: (n: number) => (n === 1 ? 0 : 1)
+			},
+			onBeforeFileAdded: () => {
+				// There's a default duplicate check in Uppy (if an item was already added in current session). We're overriding this behavior to handle the duplicate files
+				// later when the file is added to the list of files to upload.
+				return true;
 			}
 		}).use(XHRUpload, xhrOptions);
 		onFileAdded &&


### PR DESCRIPTION
https://github.com/craftersoftware/craftercms/issues/7231

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved duplicate file handling during uploads by allowing duplicate selections to proceed to the upload list for later processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->