### PR TITLE
[7830] Update log level for duplicate item drop target

### DIFF
--- a/studio-ui/ui/guest/src/store/epics/root.ts
+++ b/studio-ui/ui/guest/src/store/epics/root.ts
@@ -1044,7 +1044,7 @@ const epic = combineEpics<GuestStandardAction, GuestStandardAction, GuestState>(
 										id: 'instanceDragStarted.duplicateItem',
 										defaultMessage: 'Drop targets do not allow duplicate items.'
 									}),
-									level: 'info'
+									level: 'required'
 								})
 							);
 						} else {


### PR DESCRIPTION
https://github.com/craftersoftware/craftercms/issues/7830

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the duplicate-item drag warning to display as a required message instead of an informational notice.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->