### PR TITLE
[8569] Show publishing target in Unpublished Dashlet

### DIFF
--- a/studio-ui/ui/app/src/components/UnpublishedDashlet/UnpublishedDashlet.tsx
+++ b/studio-ui/ui/app/src/components/UnpublishedDashlet/UnpublishedDashlet.tsx
@@ -313,7 +313,7 @@ export function UnpublishedDashlet(props: UnpublishedDashletProps) {
 									<ItemDisplay
 										item={item}
 										titleDisplayProp="path"
-										showPublishingTarget={false}
+										showPublishingTarget={true}
 										onClick={(e) =>
 											isPage(item.systemType) || item.availableActionsMap.view ? onItemClick(e, item) : null
 										}


### PR DESCRIPTION
Updated the Unpublished Dashlet to display publishing target, to get information about items published to staging

https://github.com/craftersoftware/craftercms/issues/8569

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Publishing target information is now displayed for unpublished items in the dashboard.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->