### PR TITLE
[8793] Do not allow a user to select a soft publishing dependency for publish that they are not allowed to publish 

### DIFF
--- a/studio-ui/ui/app/src/components/PackageItems/utils.tsx
+++ b/studio-ui/ui/app/src/components/PackageItems/utils.tsx
@@ -28,6 +28,8 @@ import MoreVertRounded from '@mui/icons-material/MoreVertRounded';
 import Checkbox from '@mui/material/Checkbox';
 import FolderOpenRoundedIcon from '@mui/icons-material/FolderOpenRounded';
 import { DraftChip } from '../DraftChip';
+import Tooltip from '@mui/material/Tooltip';
+import { FormattedMessage } from 'react-intl';
 
 export function renderTreeNode(props: {
 	itemMap: LookupTable<LightItem>;
@@ -92,14 +94,27 @@ export function renderTreeNode(props: {
 								<MoreVertRounded />
 							</IconButton>
 							{isSoft && (
-								<Checkbox
-									size="small"
-									checked={selectedDependencies?.includes(node.path)}
-									onClick={(e) => e.stopPropagation()}
-									onChange={(e, checked) => {
-										onCheckboxChange?.(e, checked, node.path);
-									}}
-								/>
+								<Tooltip
+									title={
+										!itemMap[node.path].canRequestPublish ? (
+											<FormattedMessage defaultMessage="This reference can't be selected because you don't have permission to publish it." />
+										) : (
+											''
+										)
+									}
+								>
+									<span>
+										<Checkbox
+											size="small"
+											checked={selectedDependencies?.includes(node.path)}
+											disabled={!itemMap[node.path].canRequestPublish}
+											onClick={(e) => e.stopPropagation()}
+											onChange={(e, checked) => {
+												onCheckboxChange?.(e, checked, node.path);
+											}}
+										/>
+									</span>
+								</Tooltip>
 							)}
 						</Box>
 					</Box>

--- a/studio-ui/ui/app/src/components/PublishDialog/PublishDialogContainer.tsx
+++ b/studio-ui/ui/app/src/components/PublishDialog/PublishDialogContainer.tsx
@@ -315,6 +315,7 @@ export function PublishDialogContainer(props: PublishDialogContainerProps) {
 
 	const handleSubmit = (e?: SyntheticEvent) => {
 		e?.preventDefault();
+		if (submitDisabled) return;
 
 		const { publishingTarget, scheduling: schedule } = state;
 		const { itemPaths, itemMap } = itemsDataSummary;

--- a/studio-ui/ui/app/src/components/PublishDialog/PublishDialogContainer.tsx
+++ b/studio-ui/ui/app/src/components/PublishDialog/PublishDialogContainer.tsx
@@ -81,6 +81,7 @@ export function PublishDialogContainer(props: PublishDialogContainerProps) {
 	const dispatch = useDispatch();
 	const [contentItems, setContentItems] = useState<ContentItem[]>();
 	const [isFetchingItems, setIsFetchingItems] = useState(false);
+	const [packageDependenciesFetchFailed, setPackageDependenciesFetchFailed] = useState(false);
 	const [state, setState] = useSpreadState<InternalDialogState>({
 		packageTitle: '',
 		requestApproval: false,
@@ -139,10 +140,15 @@ export function PublishDialogContainer(props: PublishDialogContainerProps) {
 	}, [itemsDataSummary.itemPaths, itemsByPath]);
 
 	const hardDependenciesWithoutPublishPermission = useMemo(() => {
-		return dependencyData?.items.some(
+		if (packageDependenciesFetchFailed || !dependencyData) {
+			return false;
+		}
+		return dependencyData.items.some(
 			(item) => !item.canRequestPublish && dependencyData.typeByPath[item.path] === 'hard'
 		);
-	}, [dependencyData]);
+	}, [dependencyData, packageDependenciesFetchFailed]);
+	const dependencyValidationIncomplete =
+		packageDependenciesFetchFailed || (!dependencyData && Boolean(state.publishingTarget));
 
 	// Auto-generate submission comment based on mainItems labels if comment is blank
 	useEffect(() => {
@@ -227,6 +233,8 @@ export function PublishDialogContainer(props: PublishDialogContainerProps) {
 		state.scheduledDateTime < new Date() ||
 		// All items to publish are empty folders.
 		arePublishingItemsFolders ||
+		// When dependency validation did not complete successfully
+		dependencyValidationIncomplete ||
 		// When there are hard dependencies without publish permission
 		hardDependenciesWithoutPublishPermission;
 
@@ -252,6 +260,7 @@ export function PublishDialogContainer(props: PublishDialogContainerProps) {
 						depMap[path] = 'soft';
 					});
 					setState({ fetchingItems: false });
+					setPackageDependenciesFetchFailed(false);
 					if (includeChildren && dependenciesByType.items) {
 						if (itemsArrayChanged(effectRefs.current.childrenItems, dependenciesByType.items)) {
 							setChildrenItems(dependenciesByType.items);
@@ -270,7 +279,9 @@ export function PublishDialogContainer(props: PublishDialogContainerProps) {
 				},
 				error() {
 					setState({ fetchingItems: false });
+					setIsFetchingItems(false);
 					setDependencyData(null);
+					setPackageDependenciesFetchFailed(true);
 				}
 			});
 			return () => sub.unsubscribe();
@@ -502,6 +513,13 @@ export function PublishDialogContainer(props: PublishDialogContainerProps) {
 													sx={{ borderTopRightRadius: 0, borderTopLeftRadius: 0 }}
 												>
 													<FormattedMessage defaultMessage="Last applied changes can be reverted" />
+												</Alert>
+											</Fade>
+										)}
+										{packageDependenciesFetchFailed && (
+											<Fade in={packageDependenciesFetchFailed}>
+												<Alert severity="error" sx={{ borderTopRightRadius: 0, borderTopLeftRadius: 0 }}>
+													<FormattedMessage defaultMessage="Dependency validation could not complete. Please try again before submitting." />
 												</Alert>
 											</Fade>
 										)}

--- a/studio-ui/ui/app/src/components/PublishDialog/PublishDialogContainer.tsx
+++ b/studio-ui/ui/app/src/components/PublishDialog/PublishDialogContainer.tsx
@@ -138,6 +138,12 @@ export function PublishDialogContainer(props: PublishDialogContainerProps) {
 		return itemsDataSummary.itemPaths.some((path) => itemsByPath[path]?.savedAsDraft);
 	}, [itemsDataSummary.itemPaths, itemsByPath]);
 
+	const hardDependenciesWithoutPublishPermission = useMemo(() => {
+		return dependencyData?.items.some(
+			(item) => !item.canRequestPublish && dependencyData.typeByPath[item.path] === 'hard'
+		);
+	}, [dependencyData]);
+
 	// Auto-generate submission comment based on mainItems labels if comment is blank
 	useEffect(() => {
 		if (state && mainItems && Array.isArray(mainItems) && isBlank(state.submissionComment)) {
@@ -220,7 +226,9 @@ export function PublishDialogContainer(props: PublishDialogContainerProps) {
 		// The scheduled date is in the past
 		state.scheduledDateTime < new Date() ||
 		// All items to publish are empty folders.
-		arePublishingItemsFolders;
+		arePublishingItemsFolders ||
+		// When there are hard dependencies without publish permission
+		hardDependenciesWithoutPublishPermission;
 
 	useEffect(() => {
 		setState({ fetchingItems: true });
@@ -494,6 +502,13 @@ export function PublishDialogContainer(props: PublishDialogContainerProps) {
 													sx={{ borderTopRightRadius: 0, borderTopLeftRadius: 0 }}
 												>
 													<FormattedMessage defaultMessage="Last applied changes can be reverted" />
+												</Alert>
+											</Fade>
+										)}
+										{hardDependenciesWithoutPublishPermission && (
+											<Fade in={hardDependenciesWithoutPublishPermission}>
+												<Alert severity="error" sx={{ borderTopRightRadius: 0, borderTopLeftRadius: 0 }}>
+													<FormattedMessage defaultMessage="Package cannot be submitted because there are required references without publish permission" />
 												</Alert>
 											</Fade>
 										)}

--- a/studio-ui/ui/app/src/components/PublishDialog/PublishDialogContainer.tsx
+++ b/studio-ui/ui/app/src/components/PublishDialog/PublishDialogContainer.tsx
@@ -214,6 +214,8 @@ export function PublishDialogContainer(props: PublishDialogContainerProps) {
 	const submitDisabled =
 		// Detailed items haven't loaded
 		isFetchingItems ||
+		// While fetching dependencies
+		state.fetchingItems ||
 		!contentItems ||
 		// While submitting
 		isSubmitting ||

--- a/studio-ui/ui/app/src/components/PublishDialog/PublishPackageItemsView.tsx
+++ b/studio-ui/ui/app/src/components/PublishDialog/PublishPackageItemsView.tsx
@@ -16,7 +16,7 @@
 
 import Box from '@mui/material/Box';
 import { listItemSecondaryActionClasses } from '@mui/material';
-import { useIntl } from 'react-intl';
+import { FormattedMessage, useIntl } from 'react-intl';
 import Divider from '@mui/material/Divider';
 import IconButton from '@mui/material/IconButton';
 import { SimpleTreeView } from '@mui/x-tree-view/SimpleTreeView';
@@ -45,6 +45,7 @@ import useItemsByPath from '../../hooks/useItemsByPath';
 import { fetchContentItem } from '../../services/content';
 import { List, type RowComponentProps } from 'react-window';
 import DraftChip from '../DraftChip';
+import Tooltip from '@mui/material/Tooltip';
 
 export interface PublishItemsProps {
 	itemMap: Record<string, LightItem>;
@@ -214,11 +215,24 @@ export function PublishPackageItemsView(props: PublishItemsProps) {
 													<MoreVertRounded />
 												</IconButton>
 												{dependencyTypeMap?.[path] === 'soft' && (
-													<Checkbox
-														size="small"
-														checked={selectedDependenciesMap[path]}
-														onChange={(e, checked) => onCheckboxChange?.(e, checked, path)}
-													/>
+													<Tooltip
+														title={
+															!itemMap[path].canRequestPublish ? (
+																<FormattedMessage defaultMessage="This reference can't be selected because you don't have permission to publish it." />
+															) : (
+																''
+															)
+														}
+													>
+														<span>
+															<Checkbox
+																size="small"
+																disabled={!itemMap[path].canRequestPublish}
+																checked={selectedDependenciesMap[path]}
+																onChange={(e, checked) => onCheckboxChange?.(e, checked, path)}
+															/>
+														</span>
+													</Tooltip>
 												)}
 											</Box>
 										}

--- a/studio-ui/ui/app/src/models/Item.ts
+++ b/studio-ui/ui/app/src/models/Item.ts
@@ -125,6 +125,8 @@ export interface LightItem {
 	label: string;
 	systemType: SystemType;
 	mimeType: string;
+	canApprove?: boolean;
+	canRequestPublish?: boolean;
 }
 
 export interface ContentItem extends LightItem {


### PR DESCRIPTION
https://github.com/craftersoftware/craftercms/issues/8793

This needs to be merged with https://github.com/craftersoftware/craftercms/pull/8888

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Disabled publishing options for items that cannot be requested or published.
  - Added localized tooltips explaining why unavailable soft dependencies cannot be selected.
  - Prevented submission when required dependencies lack publishing permission, dependency data is unavailable, or validation fails.
  - Displayed separate error alerts in the publish dialog for permission and validation issues.
  - Improved dependency validation status handling when package details are recalculated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->