### PR TITLE
Remove unused delete_users permission

### DIFF
--- a/studio/src/main/resources/crafter/studio/upgrade/5.0.x/system/global-permission-mappings-config-v5.0.0.25.xslt
+++ b/studio/src/main/resources/crafter/studio/upgrade/5.0.x/system/global-permission-mappings-config-v5.0.0.25.xslt
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  * Copyright (C) 2007-2026 Crafter Software Corporation. All Rights Reserved.
+  *
+  * This program is free software: you can redistribute it and/or modify
+  * it under the terms of the GNU General Public License version 3 as published by
+  * the Free Software Foundation.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  * GNU General Public License for more details.
+  *
+  * You should have received a copy of the GNU General Public License
+  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0">
+
+	<!-- to keep the right formatting -->
+	<xsl:output method="xml" indent="yes"/>
+	<xsl:strip-space elements="*"/>
+
+	<!-- copy all elements -->
+	<xsl:template match="node() | @*">
+		<!-- insert line breaks before comments -->
+		<xsl:if test="self::comment()">
+			<xsl:text>&#10;</xsl:text>
+		</xsl:if>
+		<xsl:copy>
+			<xsl:apply-templates select="node() | @*"/>
+		</xsl:copy>
+		<!-- insert line breaks after comments -->
+		<xsl:if test="self::comment()">
+			<xsl:text>&#10;</xsl:text>
+		</xsl:if>
+	</xsl:template>
+
+	<!-- Remove delete_users permission -->
+	<xsl:template match="permissions/role/rule/allowed-permissions/permission">
+		<xsl:choose>
+			<xsl:when test="text() = 'delete_users'">
+				<!-- Remove -->
+			</xsl:when>
+			<xsl:otherwise>
+				<xsl:copy>
+					<xsl:copy-of select="@*"/>
+					<xsl:apply-templates/>
+				</xsl:copy>
+			</xsl:otherwise>
+		</xsl:choose>
+	</xsl:template>
+
+</xsl:stylesheet>

--- a/studio/src/main/resources/crafter/studio/upgrade/pipelines.yaml
+++ b/studio/src/main/resources/crafter/studio/upgrade/pipelines.yaml
@@ -656,6 +656,14 @@ pipelines:
                 operations:
                     -   type: dbScriptUpgrader
                         filename: upgrade/5.0.x/5.0.0.23-to-5.0.0.24.sql
+            -   currentVersion: 5.0.0.24
+                nextVersion: 5.0.0.25
+                operations:
+                    -   type: xsltFileUpgrader
+                        path: /configuration/global-permission-mappings-config.xml
+                        template: crafter/studio/upgrade/5.0.x/system/global-permission-mappings-config-v5.0.0.25.xslt
+                        commitDetails: Remove unused permissions
+
 
 
     # Pipeline to upgrade site repositories

--- a/studio/src/test/java/org/craftercms/studio/XsltTest.java
+++ b/studio/src/test/java/org/craftercms/studio/XsltTest.java
@@ -528,6 +528,23 @@ public class XsltTest {
 		testXsltTemplate(template, content, expected, params);
 	}
 
+	@DataProvider(name = "globalPermissions50025TestData")
+	public Object[][] globalPermissions50025TestData() {
+		return new Object[][]{
+				new Object[] {
+						new ClassPathResource("crafter/studio/upgrade/5.0.x/system/global-permission-mappings-config-v5.0.0.25.xslt"),
+						new ClassPathResource("crafter/studio/upgrade/xslt/global-permission-mappings/5.0/5.0.0.25/input.xml"),
+						new ClassPathResource("crafter/studio/upgrade/xslt/global-permission-mappings/5.0/5.0.0.25/expected.xml"),
+						emptyMap()
+				}
+		};
+	}
+
+	@Test(dataProvider = "globalPermissions50025TestData")
+	public void globalPermissions50025Test(Resource template, Resource content, Resource expected, Map<String, Object> params) throws IOException, TransformerException {
+		testXsltTemplate(template, content, expected, params);
+	}
+
 	private void testXsltTemplate(Resource template, Resource content, Resource expected, Map<String, Object> params)
 		throws IOException, TransformerException {
 		try (InputStream templateIs = template.getInputStream();

--- a/studio/src/test/resources/crafter/studio/upgrade/xslt/global-permission-mappings/5.0/5.0.0.25/expected.xml
+++ b/studio/src/test/resources/crafter/studio/upgrade/xslt/global-permission-mappings/5.0/5.0.0.25/expected.xml
@@ -97,7 +97,8 @@
 				<permission>cancel_failed_pull</permission>
 				<permission>publish_cancel</permission>
 				<permission>publish_request</permission>
-				<permission>publish_review</permission>
+				<permission>publish_approve</permission>
+				<permission>publish_reject</permission>
 				<permission>system_properties_read</permission>
 				<permission>system_properties_manage</permission>
 			</allowed-permissions>

--- a/studio/src/test/resources/crafter/studio/upgrade/xslt/global-permission-mappings/5.0/5.0.0.25/input.xml
+++ b/studio/src/test/resources/crafter/studio/upgrade/xslt/global-permission-mappings/5.0/5.0.0.25/input.xml
@@ -55,6 +55,7 @@
 				<permission>read_users</permission>
 				<permission>create_users</permission>
 				<permission>update_users</permission>
+				<permission>delete_users</permission>
 				<permission>read_cluster</permission>
 				<permission>audit_log</permission>
 				<permission>read_logs</permission>
@@ -97,7 +98,8 @@
 				<permission>cancel_failed_pull</permission>
 				<permission>publish_cancel</permission>
 				<permission>publish_request</permission>
-				<permission>publish_review</permission>
+				<permission>publish_approve</permission>
+				<permission>publish_reject</permission>
 				<permission>system_properties_read</permission>
 				<permission>system_properties_manage</permission>
 			</allowed-permissions>


### PR DESCRIPTION
Remove unused delete_users permission
https://github.com/craftersoftware/craftercms/issues/5424

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the obsolete `delete_users` permission from the global system administrator role.
  * Added an upgrade path to automatically update existing permission configurations.
* **Tests**
  * Added validation to confirm permission mappings are transformed correctly during upgrades.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->