### PR TITLE
[8095] Add sorting to pages DS, fix sort not applying

### DIFF
--- a/studio-ui/ui/app/src/components/ContentTypeManagement/descriptors/dataSources/pages.ts
+++ b/studio-ui/ui/app/src/components/ContentTypeManagement/descriptors/dataSources/pages.ts
@@ -35,7 +35,9 @@ export const pagesDataSourceDescriptor: DescriptorContentType = {
 				'baseRepoPath',
 				'baseBrowsePath',
 				'contentTypes',
-				'tags'
+				'tags',
+				'sortBy',
+				'sortOrder'
 			]
 		})
 	],
@@ -98,6 +100,26 @@ export const pagesDataSourceDescriptor: DescriptorContentType = {
 			name: defineMessage({ defaultMessage: 'Tags' }),
 			defaultValue: undefined,
 			validations: immutableEmptyObject
+		},
+		sortBy: {
+			id: 'sortBy',
+			type: 'sort-dropdown',
+			name: defineMessage({ defaultMessage: 'Sort By' }),
+			defaultValue: '-AUTO-',
+			validations: immutableEmptyObject,
+			properties: {
+				type: { name: 'type', type: 'string', value: 'sortBy' }
+			}
+		},
+		sortOrder: {
+			id: 'sortOrder',
+			type: 'sort-dropdown',
+			name: defineMessage({ defaultMessage: 'Sort Order' }),
+			defaultValue: undefined,
+			validations: immutableEmptyObject,
+			properties: {
+				type: { name: 'type', type: 'string', value: 'sortOrder' }
+			}
 		}
 	}
 };

--- a/studio-ui/ui/app/src/components/FormsEngine/dataSources/moduleHelpers.ts
+++ b/studio-ui/ui/app/src/components/FormsEngine/dataSources/moduleHelpers.ts
@@ -274,7 +274,11 @@ export function createBrowseAction(options: {
 				path: expanded,
 				contentTypes,
 				mimeTypes,
-				multiSelect: (ctx.remainingCapacity ?? 2) !== 1
+				multiSelect: (ctx.remainingCapacity ?? 2) !== 1,
+				initialParameters: {
+					sortBy: options.meta?.sortBy,
+					sortOrder: options.meta?.sortOrder
+				}
 			});
 			if (!items.length) return null;
 			return selection === 'asset' ? toAssetSelections(items) : toItemSelections(items);
@@ -307,7 +311,10 @@ export function createSearchAction(options: {
 		},
 		async run(ctx) {
 			const expanded = toSearchPath(expandPathOrRaw(ctx, path));
-			const initialParameters: Record<string, unknown> = {};
+			const initialParameters: Record<string, unknown> = {
+				sortBy: options.meta?.sortBy,
+				sortOrder: options.meta?.sortOrder
+			};
 			if (mimeTypes?.length) {
 				initialParameters.filters = { 'mime-type': mimeTypes };
 			}


### PR DESCRIPTION
https://github.com/craftersoftware/craftercms/issues/8095

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added sorting options for Pages data sources, including sort field and sort order.
  - Browse and search results now apply the selected sorting preferences while preserving MIME-type filters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->