### PR TITLE
[8869] Create content via Form should provide a default comment

### DIFF
--- a/studio-ui/ui/app/src/components/FormsEngine/FormsEngine.tsx
+++ b/studio-ui/ui/app/src/components/FormsEngine/FormsEngine.tsx
@@ -762,7 +762,12 @@ function FormOrchestrator(props: FormsEngineProps) {
 				if (changedFieldIds.has(XmlKeys.fileName)) {
 					const pageUrl = store.get(effectRefs.current.fileNameAtom);
 					if (pageUrl)
-						store.set(versionCommentAtom, formatMessage({ defaultMessage: 'Created {pageUrl}' }, { pageUrl }));
+						store.set(
+							versionCommentAtom,
+							pageUrl
+								? formatMessage({ defaultMessage: 'Created {pageUrl}' }, { pageUrl })
+								: formatMessage({ defaultMessage: 'Created content' })
+						);
 				}
 				return;
 			}
@@ -777,7 +782,16 @@ function FormOrchestrator(props: FormsEngineProps) {
 		return () => {
 			sub.unsubscribe();
 		};
-	}, [changedFieldIds, contentType.fields, effectRefs, setHasPendingChanges, fieldUpdates$, store, isCreateMode]);
+	}, [
+		changedFieldIds,
+		contentType.fields,
+		effectRefs,
+		setHasPendingChanges,
+		fieldUpdates$,
+		store,
+		isCreateMode,
+		formatMessage
+	]);
 
 	const sourceMapPaths = useMemo(() => Object.values(sourceMap ?? []).sort(), [sourceMap]);
 	useFetchContentItems(sourceMapPaths);

--- a/studio-ui/ui/app/src/components/FormsEngine/FormsEngine.tsx
+++ b/studio-ui/ui/app/src/components/FormsEngine/FormsEngine.tsx
@@ -96,6 +96,7 @@ import {
 	displayFormBeingSavedSnack,
 	fetchUpdateRequirements,
 	generateDefaultChangesComment,
+	generateDefaultCreationComment,
 	getAdditionalFieldsIdsFromDescriptor,
 	resolveControlDescriptors,
 	getCurrentChildFormStateSummary,
@@ -104,6 +105,7 @@ import {
 	internalLockContentService,
 	internalUnlockContentService,
 	prepareEmbeddedItemForm,
+	produceCreationMessage,
 	setFieldAtoms,
 	useUnlockOnClose,
 	useValidateFormProps
@@ -494,7 +496,7 @@ function FormBootstrap(props: FormsEngineProps) {
 				expandedStateBySectionId: buildSectionExpandedStateAtoms(contentType.sections),
 				fileName: atom(''),
 				// Default version comment for new content.
-				versionComment: atom(formatMessage({ defaultMessage: 'Created content' }))
+				versionComment: atom(produceCreationMessage('', formatMessage))
 			});
 			const contentObject = createObjectWithSystemProps(contentType);
 			const values = createParsedValuesObject(
@@ -724,6 +726,9 @@ function FormOrchestrator(props: FormsEngineProps) {
 		fileNameAtom: stableFormContext.atoms.fileName,
 		lockStatus
 	});
+	// Holds the create mode comment generated last, so that a comment written by the user isn't overwritten. Starts off
+	// with the default comment the version comment atom was created with.
+	const lastCreationCommentRef = useRef(produceCreationMessage('', formatMessage));
 	const [collapseHeader, setCollapseHeader] = useState(false);
 	const [saveAsDraftAction, setSaveAsDraftAction] = useState(false);
 	const [invalidForm, setInvalidForm] = useState(false);
@@ -757,16 +762,18 @@ function FormOrchestrator(props: FormsEngineProps) {
 			// emitted is in changedFieldIds should tell if the field was rolled back.
 			setHasPendingChanges(changedFieldIds.size > 0);
 			const versionCommentAtom = effectRefs.current.versionCommentAtom;
-			// Create mode uses a fixed default comment; only update when the page URL (file-name) changes.
+			// Create mode bases the comment off of the page URL (file-name) instead of the fields changed. Note that any
+			// field update re-runs this since every field's validation depends on the file name.
 			if (isCreateMode) {
-				if (changedFieldIds.has(XmlKeys.fileName)) {
-					const pageUrl = store.get(effectRefs.current.fileNameAtom);
-					store.set(
-						versionCommentAtom,
-						pageUrl
-							? formatMessage({ defaultMessage: 'Created {pageUrl}' }, { pageUrl })
-							: formatMessage({ defaultMessage: 'Created content' })
-					);
+				const newMessage = generateDefaultCreationComment(
+					store.get(effectRefs.current.fileNameAtom),
+					store.get(versionCommentAtom).trim(),
+					lastCreationCommentRef.current,
+					formatMessage
+				);
+				if (newMessage) {
+					lastCreationCommentRef.current = newMessage;
+					store.set(versionCommentAtom, newMessage);
 				}
 				return;
 			}

--- a/studio-ui/ui/app/src/components/FormsEngine/FormsEngine.tsx
+++ b/studio-ui/ui/app/src/components/FormsEngine/FormsEngine.tsx
@@ -286,6 +286,7 @@ function FormBootstrap(props: FormsEngineProps) {
 	const triggerReload = useCallback(() => setReloadNonce((nonce) => nonce + 1), []);
 	const effectiveUpdatePath = renamedPath ?? update?.path;
 	const customControls = useSelection((state) => state.uiConfig.controls);
+	const { formatMessage } = useIntl();
 
 	const contextApi = useMemo<FormsEngineFormApiContextProps>(() => {
 		const getInitialValues = () => stableFormContextRef.current.originalValues;
@@ -491,7 +492,9 @@ function FormBootstrap(props: FormsEngineProps) {
 				lockResult: lockResultAtom,
 				readonly: atom(false),
 				expandedStateBySectionId: buildSectionExpandedStateAtoms(contentType.sections),
-				fileName: atom('')
+				fileName: atom(''),
+				// Default version comment for new content.
+				versionComment: atom(formatMessage({ defaultMessage: 'Created content' }))
 			});
 			const contentObject = createObjectWithSystemProps(contentType);
 			const values = createParsedValuesObject(
@@ -718,6 +721,7 @@ function FormOrchestrator(props: FormsEngineProps) {
 	const effectRefs = useUpdateRefs({
 		fieldsToRender,
 		versionCommentAtom: stableFormContext.atoms.versionComment,
+		fileNameAtom: stableFormContext.atoms.fileName,
 		lockStatus
 	});
 	const [collapseHeader, setCollapseHeader] = useState(false);
@@ -752,9 +756,16 @@ function FormOrchestrator(props: FormsEngineProps) {
 			// String-type fields have auto-rollback detection; the fieldUpdates$ will emit anyway. Checking if the fieldId
 			// emitted is in changedFieldIds should tell if the field was rolled back.
 			setHasPendingChanges(changedFieldIds.size > 0);
-			// No comment generation for content creation.
-			if (isCreateMode) return;
 			const versionCommentAtom = effectRefs.current.versionCommentAtom;
+			// Create mode uses a fixed default comment; only update when the page URL (file-name) changes.
+			if (isCreateMode) {
+				if (changedFieldIds.has(XmlKeys.fileName)) {
+					const pageUrl = store.get(effectRefs.current.fileNameAtom);
+					if (pageUrl)
+						store.set(versionCommentAtom, formatMessage({ defaultMessage: 'Created {pageUrl}' }, { pageUrl }));
+				}
+				return;
+			}
 			const newMessage = generateDefaultChangesComment(
 				contentType.fields,
 				effectRefs.current.fieldsToRender,

--- a/studio-ui/ui/app/src/components/FormsEngine/FormsEngine.tsx
+++ b/studio-ui/ui/app/src/components/FormsEngine/FormsEngine.tsx
@@ -761,13 +761,12 @@ function FormOrchestrator(props: FormsEngineProps) {
 			if (isCreateMode) {
 				if (changedFieldIds.has(XmlKeys.fileName)) {
 					const pageUrl = store.get(effectRefs.current.fileNameAtom);
-					if (pageUrl)
-						store.set(
-							versionCommentAtom,
-							pageUrl
-								? formatMessage({ defaultMessage: 'Created {pageUrl}' }, { pageUrl })
-								: formatMessage({ defaultMessage: 'Created content' })
-						);
+					store.set(
+						versionCommentAtom,
+						pageUrl
+							? formatMessage({ defaultMessage: 'Created {pageUrl}' }, { pageUrl })
+							: formatMessage({ defaultMessage: 'Created content' })
+					);
 				}
 				return;
 			}

--- a/studio-ui/ui/app/src/components/FormsEngine/FormsEngine.tsx
+++ b/studio-ui/ui/app/src/components/FormsEngine/FormsEngine.tsx
@@ -105,7 +105,6 @@ import {
 	internalLockContentService,
 	internalUnlockContentService,
 	prepareEmbeddedItemForm,
-	produceCreationMessage,
 	setFieldAtoms,
 	useUnlockOnClose,
 	useValidateFormProps
@@ -496,7 +495,7 @@ function FormBootstrap(props: FormsEngineProps) {
 				expandedStateBySectionId: buildSectionExpandedStateAtoms(contentType.sections),
 				fileName: atom(''),
 				// Default version comment for new content.
-				versionComment: atom(produceCreationMessage('', formatMessage))
+				versionComment: atom(generateDefaultCreationComment('', formatMessage))
 			});
 			const contentObject = createObjectWithSystemProps(contentType);
 			const values = createParsedValuesObject(
@@ -728,7 +727,7 @@ function FormOrchestrator(props: FormsEngineProps) {
 	});
 	// Holds the create mode comment generated last, so that a comment written by the user isn't overwritten. Starts off
 	// with the default comment the version comment atom was created with.
-	const lastCreationCommentRef = useRef(produceCreationMessage('', formatMessage));
+	const lastCreationCommentRef = useRef(generateDefaultCreationComment('', formatMessage));
 	const [collapseHeader, setCollapseHeader] = useState(false);
 	const [saveAsDraftAction, setSaveAsDraftAction] = useState(false);
 	const [invalidForm, setInvalidForm] = useState(false);
@@ -767,9 +766,9 @@ function FormOrchestrator(props: FormsEngineProps) {
 			if (isCreateMode) {
 				const newMessage = generateDefaultCreationComment(
 					store.get(effectRefs.current.fileNameAtom),
+					formatMessage,
 					store.get(versionCommentAtom).trim(),
 					lastCreationCommentRef.current,
-					formatMessage
 				);
 				if (newMessage) {
 					lastCreationCommentRef.current = newMessage;

--- a/studio-ui/ui/app/src/components/FormsEngine/lib/formUtils.tsx
+++ b/studio-ui/ui/app/src/components/FormsEngine/lib/formUtils.tsx
@@ -797,6 +797,48 @@ export function generateDefaultChangesComment(
 }
 
 /**
+ * Produces the "save comment" for content being created at the supplied page URL (file name). An empty page URL
+ * produces the generic comment new content forms start off with.
+ **/
+export function produceCreationMessage(pageUrl: string, formatMessage: IntlShape['formatMessage']): string {
+	return pageUrl
+		? formatMessage({ defaultMessage: 'Created {pageUrl}' }, { pageUrl })
+		: formatMessage({ defaultMessage: 'Created content' });
+}
+
+/**
+ * Generates the default "save comment" for content being created, based on the page URL (file name) it will be
+ * created at.
+ * @param pageUrl The current value of the file name field.
+ * @param currentMessage The version comment currently held by the form.
+ * @param lastGeneratedMessage The comment this function generated last, used to detect user input on the comment.
+ * @returns The new comment, or undefined when the comment should be left untouched.
+ **/
+export function generateDefaultCreationComment(
+	pageUrl: string,
+	currentMessage: string,
+	lastGeneratedMessage: string,
+	formatMessage: IntlShape['formatMessage']
+): string | undefined {
+	const newMessage = pageUrl
+		? formatMessage({ defaultMessage: 'Created {pageUrl}' }, { pageUrl })
+		: formatMessage({ defaultMessage: 'Created content' });
+	if (
+		// Nothing to change
+		currentMessage === newMessage ||
+		// If message is blank, no point in checking if the user has altered the message.
+		(currentMessage !== '' &&
+			// The version comment has been manually altered by the user (i.e. if the current message isn't the last
+			// message generated here, we can assume the message has been altered by user input)
+			currentMessage !== lastGeneratedMessage)
+	) {
+		// Do not set a new message
+		return;
+	}
+	return newMessage;
+}
+
+/**
  * Creates a summary of the state the current stacked form being rendered (last one on the stack)
  **/
 export function getCurrentChildFormStateSummary(

--- a/studio-ui/ui/app/src/components/FormsEngine/lib/formUtils.tsx
+++ b/studio-ui/ui/app/src/components/FormsEngine/lib/formUtils.tsx
@@ -797,16 +797,6 @@ export function generateDefaultChangesComment(
 }
 
 /**
- * Produces the "save comment" for content being created at the supplied page URL (file name). An empty page URL
- * produces the generic comment new content forms start off with.
- **/
-export function produceCreationMessage(pageUrl: string, formatMessage: IntlShape['formatMessage']): string {
-	return pageUrl
-		? formatMessage({ defaultMessage: 'Created {pageUrl}' }, { pageUrl })
-		: formatMessage({ defaultMessage: 'Created content' });
-}
-
-/**
  * Generates the default "save comment" for content being created, based on the page URL (file name) it will be
  * created at.
  * @param pageUrl The current value of the file name field.
@@ -816,13 +806,18 @@ export function produceCreationMessage(pageUrl: string, formatMessage: IntlShape
  **/
 export function generateDefaultCreationComment(
 	pageUrl: string,
-	currentMessage: string,
-	lastGeneratedMessage: string,
-	formatMessage: IntlShape['formatMessage']
+	formatMessage: IntlShape['formatMessage'],
+	currentMessage?: string,
+	lastGeneratedMessage?: string,
 ): string | undefined {
 	const newMessage = pageUrl
 		? formatMessage({ defaultMessage: 'Created {pageUrl}' }, { pageUrl })
 		: formatMessage({ defaultMessage: 'Created content' });
+
+	if (!currentMessage || !lastGeneratedMessage) {
+		return newMessage;
+	}
+		
 	if (
 		// Nothing to change
 		currentMessage === newMessage ||


### PR DESCRIPTION
https://github.com/craftersoftware/craftercms/issues/8869

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added localized creation comments for new forms.
  * New forms now start with a default “Created content” comment.
  * Comments update with the file name when it changes, while preserving manually edited comments.
  * Default comments reset when the file name is cleared.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->