### PR TITLE
Fix build number replacement in version info template

### DIFF
--- a/engine/src/main/generated-resources/versionInfo.ftl
+++ b/engine/src/main/generated-resources/versionInfo.ftl
@@ -1,2 +1,2 @@
-<#assign buildId="${buildNumber}"/>
-<#assign buildOn="${timestamp}"/>
+<#assign buildId="@buildNumber@"/>
+<#assign buildOn="@timestamp@"/>

--- a/gradle/build-metadata.gradle
+++ b/gradle/build-metadata.gradle
@@ -18,6 +18,7 @@
  * Shared build metadata for manifest attributes and resource token replacement.
  * Matches Maven buildnumber-maven-plugin behavior:
  *   - buildNumber: SCM revision (git commit), or 'unknown' if unavailable
+ *   - UIbuildNumber: SCM revision of studio-ui, part of this repo since the monorepo migration
  *   - timestamp: epoch milliseconds for the Build-On manifest attribute
  *   - crafterManifestTitle: human-friendly Implementation-Title, set in each module's build.gradle
  */
@@ -38,9 +39,12 @@ def resolveBuildTimestamp = {
 	return System.currentTimeMillis().toString()
 }
 
+def scmBuildNumber = resolveScmBuildNumber()
+
 ext.crafterBuildMetadata = [
-	buildNumber: resolveScmBuildNumber(),
-	timestamp  : resolveBuildTimestamp()
+	buildNumber  : scmBuildNumber,
+	UIbuildNumber: findProperty('UIbuildNumber')?.toString() ?: scmBuildNumber,
+	timestamp    : resolveBuildTimestamp()
 ]
 
 ext.crafterManifestAttributes = {

--- a/gradle/war.gradle
+++ b/gradle/war.gradle
@@ -57,8 +57,10 @@ ext.configureFilteredWarResource = { warTask, sourceDir, targetPath ->
 	warTask.from(sourceDir) {
 		into targetPath
 		filter(ReplaceTokens, tokens: [
-			buildNumber: buildMetadata.buildNumber,
-			timestamp  : buildMetadata.timestamp
+			buildNumber  : buildMetadata.buildNumber,
+			UIbuildNumber: buildMetadata.UIbuildNumber,
+			timestamp    : buildMetadata.timestamp,
+			version      : project.version.toString()
 		])
 	}
 }

--- a/studio/src/main/generated-resources/ftl/versionInfo.ftl
+++ b/studio/src/main/generated-resources/ftl/versionInfo.ftl
@@ -1,3 +1,3 @@
-<#assign buildId="${buildNumber}"/>
-<#assign buildOn="${timestamp}"/>
-<#assign UIBuildId="${UIbuildNumber}"/>
+<#assign buildId="@buildNumber@"/>
+<#assign buildOn="@timestamp@"/>
+<#assign UIBuildId="@UIbuildNumber@"/>

--- a/studio/src/main/generated-resources/rest/getInfo.get.groovy
+++ b/studio/src/main/generated-resources/rest/getInfo.get.groovy
@@ -15,8 +15,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-return ["version":"${project.version}",
-         "id":"${buildNumber}",
-          "uiId":"${UIbuildNumber}",
-          "buildDate":new Date(${timestamp})
+return ["version":"@version@",
+         "id":"@buildNumber@",
+          "uiId":"@UIbuildNumber@",
+          "buildDate":new Date(@timestamp@)
 ]


### PR DESCRIPTION
Fix buildnumber 4x

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved build and release metadata handling across the application and Studio.
  - Version information now consistently includes the application version, build number, UI build number, and build timestamp.
  - Build metadata is resolved more reliably from source control or an optional configured override.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->