### PR TITLE
Remove xml API responses

### DIFF
--- a/core/src/main/java/org/craftercms/core/controller/rest/CacheRestController.java
+++ b/core/src/main/java/org/craftercms/core/controller/rest/CacheRestController.java
@@ -30,6 +30,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.Map;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 /**
  * REST service that provides several methods to handle Crafter's cache engine.
@@ -63,7 +64,7 @@ public class CacheRestController extends RestControllerBase {
 		this.authorizationToken = authorizationToken;
 	}
 
-	@RequestMapping(value = URL_CLEAR_ALL_SCOPES, method = RequestMethod.GET)
+	@RequestMapping(value = URL_CLEAR_ALL_SCOPES, method = RequestMethod.GET, produces = APPLICATION_JSON_VALUE)
 	public Map<String, Object> clearAllScopes(@RequestParam String token)
 		throws CacheException, InvalidManagementTokenException {
 		validateToken(token);
@@ -75,7 +76,7 @@ public class CacheRestController extends RestControllerBase {
 		return createResponseMessage("All cache scopes have been cleared");
 	}
 
-	@RequestMapping(value = URL_CLEAR_SCOPE, method = RequestMethod.GET)
+	@RequestMapping(value = URL_CLEAR_SCOPE, method = RequestMethod.GET, produces = APPLICATION_JSON_VALUE)
 	public Map<String, Object> clearScope(@RequestParam(REQUEST_PARAM_CONTEXT_ID) String contextId,
 					      @RequestParam String token)
 		throws InvalidContextException, CacheException, InvalidManagementTokenException {

--- a/core/src/main/java/org/craftercms/core/controller/rest/ContentStoreRestController.java
+++ b/core/src/main/java/org/craftercms/core/controller/rest/ContentStoreRestController.java
@@ -33,6 +33,8 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.context.request.WebRequest;
 
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+
 import java.beans.ConstructorProperties;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -92,7 +94,7 @@ public class ContentStoreRestController extends RestControllerBase implements In
 		itemFilter = compositeItemFilter;
 	}
 
-	@RequestMapping(value = URL_ITEM, method = RequestMethod.GET)
+	@RequestMapping(value = URL_ITEM, method = RequestMethod.GET, produces = APPLICATION_JSON_VALUE)
 	public Item getItem(WebRequest request, HttpServletResponse response,
 			    @RequestParam(REQUEST_PARAM_CONTEXT_ID) String contextId,
 			    @RequestParam(REQUEST_PARAM_URL) String url,
@@ -115,7 +117,7 @@ public class ContentStoreRestController extends RestControllerBase implements In
 		}
 	}
 
-	@RequestMapping(value = URL_CHILDREN, method = RequestMethod.GET)
+	@RequestMapping(value = URL_CHILDREN, method = RequestMethod.GET, produces = APPLICATION_JSON_VALUE)
 	public List<Item> getChildren(WebRequest request, HttpServletResponse response,
 				      @RequestParam(REQUEST_PARAM_CONTEXT_ID) String contextId,
 				      @RequestParam(REQUEST_PARAM_URL) String url,
@@ -139,7 +141,7 @@ public class ContentStoreRestController extends RestControllerBase implements In
 		}
 	}
 
-	@RequestMapping(value = URL_TREE, method = RequestMethod.GET)
+	@RequestMapping(value = URL_TREE, method = RequestMethod.GET, produces = APPLICATION_JSON_VALUE)
 	public Tree getTree(WebRequest request, HttpServletResponse response,
 			    @RequestParam(REQUEST_PARAM_CONTEXT_ID) String contextId,
 			    @RequestParam(REQUEST_PARAM_URL) String url,

--- a/core/src/main/resources/crafter/core/rest-context.xml
+++ b/core/src/main/resources/crafter/core/rest-context.xml
@@ -18,9 +18,11 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:mvc="http://www.springframework.org/schema/mvc"
+       xmlns:util="http://www.springframework.org/schema/util"
        xsi:schemaLocation="
        http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-       http://www.springframework.org/schema/mvc http://www.springframework.org/schema/mvc/spring-mvc.xsd">
+       http://www.springframework.org/schema/mvc http://www.springframework.org/schema/mvc/spring-mvc.xsd
+       http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd">
 
 	<mvc:annotation-driven/>
 
@@ -72,10 +74,29 @@
 			  value="${crafter.core.rest.views.json.renderSingleAttributeAsRootObject}"/>
 	</bean>
 
-	<!-- XML -->
-
+    <!-- XML -->
 	<bean id="crafter.xmlMarshaller" class="org.craftercms.core.util.xml.marshalling.xstream.CrafterXStreamMarshaller">
 		<property name="unsupportedClasses" value="org.springframework.validation.BindingResult"/>
+		<property name="typePermissions">
+			<list>
+				<!-- Must be first: clears XStream's built-in allow-list -->
+				<util:constant static-field="com.thoughtworks.xstream.security.NoTypePermission.NONE"/>
+				<util:constant static-field="com.thoughtworks.xstream.security.NullPermission.NULL"/>
+				<util:constant static-field="com.thoughtworks.xstream.security.PrimitiveTypePermission.PRIMITIVES"/>
+				<bean class="com.thoughtworks.xstream.security.ExplicitTypePermission">
+					<constructor-arg>
+						<array>
+							<value>java.lang.String</value>
+							<value>java.util.Map</value>
+							<value>java.util.List</value>
+							<value>java.util.HashMap</value>
+							<value>java.util.ArrayList</value>
+							<value>java.util.LinkedHashMap</value>
+						</array>
+					</constructor-arg>
+				</bean>
+			</list>
+		</property>
 	</bean>
 
 	<bean id="crafter.xmlView" class="org.springframework.web.servlet.view.xml.MarshallingView">

--- a/core/src/main/resources/crafter/core/rest-context.xml
+++ b/core/src/main/resources/crafter/core/rest-context.xml
@@ -47,7 +47,6 @@
 		<property name="defaultViews">
 			<list>
 				<ref bean="crafter.jsonView"/>
-				<ref bean="crafter.xmlView"/>
 			</list>
 		</property>
 	</bean>
@@ -99,8 +98,5 @@
 		</property>
 	</bean>
 
-	<bean id="crafter.xmlView" class="org.springframework.web.servlet.view.xml.MarshallingView">
-		<constructor-arg index="0" ref="crafter.xmlMarshaller"/>
-	</bean>
 
 </beans>

--- a/engine/src/main/java/org/craftercms/engine/controller/rest/ConfigRestController.java
+++ b/engine/src/main/java/org/craftercms/engine/controller/rest/ConfigRestController.java
@@ -24,6 +24,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import java.util.Map;
 
 import static java.util.Collections.singletonMap;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 
 /**
@@ -48,7 +49,7 @@ public class ConfigRestController {
 	/**
 	 * Indicates if the system is currently configured for preview
 	 */
-	@GetMapping(URL_MODE_PREVIEW)
+	@GetMapping(value = URL_MODE_PREVIEW, produces = APPLICATION_JSON_VALUE)
 	public Map<String, Boolean> getModePreview() {
 		return singletonMap("preview", modePreview);
 	}

--- a/engine/src/main/java/org/craftercms/engine/controller/rest/MonitoringController.java
+++ b/engine/src/main/java/org/craftercms/engine/controller/rest/MonitoringController.java
@@ -40,6 +40,7 @@ import java.util.Map;
 
 import static java.lang.String.format;
 import static org.craftercms.commons.validation.annotations.param.EsapiValidationType.SITE_ID;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 /**
  * Rest controller to provide monitoring information &amp; site logs
@@ -62,7 +63,7 @@ public class MonitoringController extends MonitoringRestControllerBase {
 		this.siteHealthCheckService = siteHealthCheckService;
 	}
 
-	@GetMapping(MonitoringRestControllerBase.ROOT_URL + LOG_URL)
+	@GetMapping(value = MonitoringRestControllerBase.ROOT_URL + LOG_URL, produces = APPLICATION_JSON_VALUE)
 	public List<Map<String, Object>> getLoggedEvents(@RequestParam @ValidSiteId String site,
 							 @Positive @RequestParam long since,
 							 @RequestParam String token) throws InvalidManagementTokenException {
@@ -71,7 +72,7 @@ public class MonitoringController extends MonitoringRestControllerBase {
 	}
 
 	@Override
-	@GetMapping(ROOT_URL + STATUS_URL)
+	@GetMapping(value = ROOT_URL + STATUS_URL, produces = APPLICATION_JSON_VALUE)
 	public ResponseEntity getCurrentStatus(@RequestParam(name = "crafterSite", required = false) String site,
 					       @RequestParam(name = "token") String token)
 		throws InvalidManagementTokenException {

--- a/engine/src/main/java/org/craftercms/engine/controller/rest/SiteCacheRestController.java
+++ b/engine/src/main/java/org/craftercms/engine/controller/rest/SiteCacheRestController.java
@@ -33,6 +33,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 
 import java.beans.ConstructorProperties;
 import java.util.Map;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 /**
  * REST controller for site cache operations. The controller uses a map of cache types mapped to
@@ -63,7 +64,7 @@ public class SiteCacheRestController extends RestControllerBase {
 		this.configuredToken = configuredToken;
 	}
 
-	@RequestMapping(value = URL_CLEAR, method = RequestMethod.GET)
+	@RequestMapping(value = URL_CLEAR, method = RequestMethod.GET, produces = APPLICATION_JSON_VALUE)
 	public Map<String, Object> clear(HttpServletRequest request, @RequestParam String token,
 									 @RequestParam(required = false) String cacheType) throws InvalidManagementTokenException {
 		validateToken(token);
@@ -71,7 +72,7 @@ public class SiteCacheRestController extends RestControllerBase {
 		return createResponseMessage(getCacheRestOperations(cacheType).clear(request));
 	}
 
-	@RequestMapping(value = URL_STATS, method = RequestMethod.GET)
+	@RequestMapping(value = URL_STATS, method = RequestMethod.GET, produces = APPLICATION_JSON_VALUE)
 	public CacheStatistics getStatistics(@RequestParam String token,
 										 @RequestParam(required = false) String cacheType) throws InvalidManagementTokenException {
 		validateToken(token);

--- a/engine/src/main/java/org/craftercms/engine/controller/rest/SiteContentStoreRestController.java
+++ b/engine/src/main/java/org/craftercms/engine/controller/rest/SiteContentStoreRestController.java
@@ -34,6 +34,7 @@ import java.beans.ConstructorProperties;
 import java.util.List;
 
 import static org.craftercms.core.controller.rest.ContentStoreRestController.*;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 /**
  * REST controller to retrieve content from the site (items and trees). It's basically a wrapper for
@@ -55,7 +56,7 @@ public class SiteContentStoreRestController extends RestControllerBase {
 		this.wrappedController = wrappedController;
 	}
 
-	@RequestMapping(value = URL_ITEM, method = RequestMethod.GET)
+	@RequestMapping(value = URL_ITEM, method = RequestMethod.GET, produces = APPLICATION_JSON_VALUE)
 	public Item getItem(WebRequest request, HttpServletResponse response,
 			    @ValidExistingContentPath
 			    @RequestParam(REQUEST_PARAM_URL) String url,
@@ -63,7 +64,7 @@ public class SiteContentStoreRestController extends RestControllerBase {
 		return wrappedController.getItem(request, response, getCurrentContextId(), url, flatten);
 	}
 
-	@RequestMapping(value = URL_CHILDREN, method = RequestMethod.GET)
+	@RequestMapping(value = URL_CHILDREN, method = RequestMethod.GET, produces = APPLICATION_JSON_VALUE)
 	public List<Item> getChildren(WebRequest request, HttpServletResponse response,
 				      @ValidExistingContentPath
 				      @RequestParam(REQUEST_PARAM_URL) String url,
@@ -71,7 +72,7 @@ public class SiteContentStoreRestController extends RestControllerBase {
 		return wrappedController.getChildren(request, response, getCurrentContextId(), url, flatten);
 	}
 
-	@RequestMapping(value = URL_TREE, method = RequestMethod.GET)
+	@RequestMapping(value = URL_TREE, method = RequestMethod.GET, produces = APPLICATION_JSON_VALUE)
 	public Tree getTree(WebRequest request, HttpServletResponse response,
 			    @ValidExistingContentPath
 			    @RequestParam(REQUEST_PARAM_URL) String url,

--- a/engine/src/main/java/org/craftercms/engine/controller/rest/SiteContextRestController.java
+++ b/engine/src/main/java/org/craftercms/engine/controller/rest/SiteContextRestController.java
@@ -34,6 +34,7 @@ import java.util.Collections;
 import java.util.Map;
 
 import static java.lang.String.format;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 /**
  * REST controller for operations related for the {@link org.craftercms.engine.service.context.SiteContext}
@@ -64,14 +65,14 @@ public class SiteContextRestController extends RestControllerBase {
 		this.contextManager = contextManager;
 	}
 
-	@GetMapping(value = URL_CONTEXT_ID)
+	@GetMapping(value = URL_CONTEXT_ID, produces = APPLICATION_JSON_VALUE)
 	public Map<String, String> getContextId(@RequestParam String token) throws InvalidManagementTokenException {
 		validateToken(token);
 
 		return Collections.singletonMap(MODEL_ATTR_ID, SiteContext.getCurrent().getContext().getId());
 	}
 
-	@GetMapping(value = URL_DESTROY)
+	@GetMapping(value = URL_DESTROY, produces = APPLICATION_JSON_VALUE)
 	public Map<String, Object> destroy(@RequestParam String token) throws InvalidManagementTokenException {
 		validateToken(token);
 
@@ -83,7 +84,7 @@ public class SiteContextRestController extends RestControllerBase {
 			"for the site is received in the future, a new site context will be created and registered.", siteName));
 	}
 
-	@GetMapping(URL_REBUILD_ALL)
+	@GetMapping(value = URL_REBUILD_ALL, produces = APPLICATION_JSON_VALUE)
 	public Map<String, Object> rebuildAll(@RequestParam String token) throws InvalidManagementTokenException {
 		validateToken(token);
 		contextManager.startRebuildAll();
@@ -91,7 +92,7 @@ public class SiteContextRestController extends RestControllerBase {
 		return createResponseMessage("Started rebuild of all site contexts");
 	}
 
-	@GetMapping(value = URL_REBUILD)
+	@GetMapping(value = URL_REBUILD, produces = APPLICATION_JSON_VALUE)
 	public Map<String, Object> rebuild(HttpServletRequest request, @RequestParam String token)
 		throws InvalidManagementTokenException {
 		validateToken(token);
@@ -110,7 +111,7 @@ public class SiteContextRestController extends RestControllerBase {
 		}
 	}
 
-	@GetMapping(URL_GRAPHQL + URL_REBUILD)
+	@GetMapping(value = URL_GRAPHQL + URL_REBUILD, produces = APPLICATION_JSON_VALUE)
 	public Map<String, Object> rebuildSchema(HttpServletRequest request, @RequestParam String token)
 		throws InvalidManagementTokenException {
 		validateToken(token);
@@ -129,7 +130,7 @@ public class SiteContextRestController extends RestControllerBase {
 		}
 	}
 
-	@GetMapping(URL_STATUS)
+	@GetMapping(value = URL_STATUS, produces = APPLICATION_JSON_VALUE)
 	public Map<String, Object> getStatus(@RequestParam String token) throws InvalidManagementTokenException {
 		validateToken(token);
 

--- a/engine/src/main/java/org/craftercms/engine/controller/rest/SiteGraphQLController.java
+++ b/engine/src/main/java/org/craftercms/engine/controller/rest/SiteGraphQLController.java
@@ -38,6 +38,7 @@ import java.util.Objects;
 
 import static graphql.ExecutionInput.newExecutionInput;
 import static java.lang.String.format;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 /**
  * Exposes the current site {@link GraphQL} instance to perform queries.
@@ -67,7 +68,7 @@ public class SiteGraphQLController extends RestControllerBase {
 		return handleRequest(query, operationName, variables);
 	}
 
-	@PostMapping
+	@PostMapping(consumes = APPLICATION_JSON_VALUE)
 	public Map<String, Object> query(@RequestBody QueryRequest request) {
 		Map<String, Object> variables = Objects.isNull(request.getVariables()) ?
 			Collections.emptyMap() :

--- a/engine/src/main/java/org/craftercms/engine/controller/rest/SiteGraphQLController.java
+++ b/engine/src/main/java/org/craftercms/engine/controller/rest/SiteGraphQLController.java
@@ -56,7 +56,7 @@ public class SiteGraphQLController extends RestControllerBase {
 
 	protected ObjectMapper objectMapper = new ObjectMapper();
 
-	@GetMapping
+	@GetMapping(produces = APPLICATION_JSON_VALUE)
 	@SuppressWarnings("unchecked")
 	public Map<String, Object> query(@RequestParam String query, @RequestParam(required = false) String operationName,
 					 @RequestParam(required = false) String variablesStr) throws IOException {
@@ -68,7 +68,7 @@ public class SiteGraphQLController extends RestControllerBase {
 		return handleRequest(query, operationName, variables);
 	}
 
-	@PostMapping(consumes = APPLICATION_JSON_VALUE)
+	@PostMapping(consumes = APPLICATION_JSON_VALUE, produces = APPLICATION_JSON_VALUE)
 	public Map<String, Object> query(@RequestBody QueryRequest request) {
 		Map<String, Object> variables = Objects.isNull(request.getVariables()) ?
 			Collections.emptyMap() :

--- a/engine/src/main/java/org/craftercms/engine/controller/rest/SiteNavigationController.java
+++ b/engine/src/main/java/org/craftercms/engine/controller/rest/SiteNavigationController.java
@@ -29,6 +29,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 
 import java.beans.ConstructorProperties;
 import java.util.List;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 /**
  * REST controller to access site navigation services.
@@ -53,14 +54,14 @@ public class SiteNavigationController extends RestControllerBase {
 		this.navBreadcrumbBuilder = navBreadcrumbBuilder;
 	}
 
-	@GetMapping(URL_TREE)
+	@GetMapping(value = URL_TREE, produces = APPLICATION_JSON_VALUE)
 	public NavItem getNavTree(@ValidExistingContentPath @RequestParam String url,
 				  @RequestParam(required = false, defaultValue = "1") int depth,
 				  @ValidExistingContentPath @RequestParam(required = false, defaultValue = "") String currentPageUrl) {
 		return navTreeBuilder.getNavTree(url, depth, currentPageUrl);
 	}
 
-	@GetMapping(URL_BREADCRUMB)
+	@GetMapping(value = URL_BREADCRUMB, produces = APPLICATION_JSON_VALUE)
 	public List<NavItem> getNavBreadcrumb(@ValidExistingContentPath
 					      @RequestParam String url,
 					      @ValidExistingContentPath

--- a/engine/src/main/java/org/craftercms/engine/controller/rest/SiteScheduledJobsController.java
+++ b/engine/src/main/java/org/craftercms/engine/controller/rest/SiteScheduledJobsController.java
@@ -28,6 +28,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 import java.util.*;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 /**
  * Rest controller to access scheduled jobs for the current site.
@@ -41,7 +42,7 @@ public class SiteScheduledJobsController extends RestControllerBase {
 	public static final String URL_ROOT = "/site/jobs";
 	public static final String URL_LIST = "/list";
 
-	@GetMapping(URL_LIST)
+	@GetMapping(value = URL_LIST, produces = APPLICATION_JSON_VALUE)
 	@SuppressWarnings("unchecked")
 	public List<Map<String, String>> listScheduledJobs() throws SchedulerException {
 		List<Map<String, String>> jobs = new LinkedList<>();

--- a/engine/src/main/java/org/craftercms/engine/controller/rest/SiteSearchController.java
+++ b/engine/src/main/java/org/craftercms/engine/controller/rest/SiteSearchController.java
@@ -54,7 +54,7 @@ public class SiteSearchController extends RestControllerBase {
 		this.searchService = searchService;
 	}
 
-	@PostMapping(URL_SEARCH)
+	@PostMapping(value = URL_SEARCH, consumes = MediaType.APPLICATION_JSON_VALUE)
 	public void search(@RequestBody Map<String, Object> request, @RequestParam Map<String, Object> parameters,
 			   HttpServletResponse response)
 		throws IOException {

--- a/engine/src/main/java/org/craftercms/engine/controller/rest/multitenant/SiteMappingsRestController.java
+++ b/engine/src/main/java/org/craftercms/engine/controller/rest/multitenant/SiteMappingsRestController.java
@@ -26,6 +26,7 @@ import org.springframework.web.bind.annotation.RequestMethod;
 
 import java.util.Collections;
 import java.util.Map;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 /**
  * REST controller for operations related to site mappings.
@@ -45,7 +46,7 @@ public class SiteMappingsRestController {
 		this.siteResolver = siteResolver;
 	}
 
-	@RequestMapping(value = URL_RELOAD, method = RequestMethod.GET)
+	@RequestMapping(value = URL_RELOAD, method = RequestMethod.GET, produces = APPLICATION_JSON_VALUE)
 	public Map<String, String> reloadMappings(HttpServletResponse response) {
 		if (siteResolver instanceof ReloadableMappingsSiteResolver) {
 			((ReloadableMappingsSiteResolver) siteResolver).reloadMappings();

--- a/engine/src/main/java/org/craftercms/engine/controller/rest/preview/ProfileRestController.java
+++ b/engine/src/main/java/org/craftercms/engine/controller/rest/preview/ProfileRestController.java
@@ -64,7 +64,7 @@ public class ProfileRestController {
 
 	private final Validator validator = ESAPI.validator();
 
-	@RequestMapping(value = "/get", method = RequestMethod.GET)
+	@RequestMapping(value = "/get", method = RequestMethod.GET, produces = APPLICATION_JSON_VALUE)
 	@SuppressWarnings("unchecked")
 	public Map<String, Object> getProfile(HttpSession session) {
 
@@ -77,7 +77,7 @@ public class ProfileRestController {
 		return profile;
 	}
 
-	@PostMapping(value = "/set", consumes = APPLICATION_JSON_VALUE)
+	@PostMapping(value = "/set", consumes = APPLICATION_JSON_VALUE, produces = APPLICATION_JSON_VALUE)
 	public ResponseEntity<Object> setProfile(@RequestBody SetProfileRequest profileRequest, HttpSession session) {
 		Map<String, Object> parameterMap = profileRequest.getParameters();
 		if (parameterMap.size() > MAXIMUM_PROPERTY_COUNT) {

--- a/engine/src/main/java/org/craftercms/engine/controller/rest/preview/ProfileRestController.java
+++ b/engine/src/main/java/org/craftercms/engine/controller/rest/preview/ProfileRestController.java
@@ -42,6 +42,7 @@ import static java.lang.String.format;
 import static java.util.function.Function.identity;
 import static java.util.stream.Collectors.toList;
 import static org.craftercms.commons.validation.annotations.param.EsapiValidationType.HTTPParameterName;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 /**
  * REST controller for integration with Crafter Profile.
@@ -76,7 +77,7 @@ public class ProfileRestController {
 		return profile;
 	}
 
-	@PostMapping("/set")
+	@PostMapping(value = "/set", consumes = APPLICATION_JSON_VALUE)
 	public ResponseEntity<Object> setProfile(@RequestBody SetProfileRequest profileRequest, HttpSession session) {
 		Map<String, Object> parameterMap = profileRequest.getParameters();
 		if (parameterMap.size() > MAXIMUM_PROPERTY_COUNT) {

--- a/studio/src/main/java/org/craftercms/studio/controller/rest/v2/AuditController.java
+++ b/studio/src/main/java/org/craftercms/studio/controller/rest/v2/AuditController.java
@@ -42,6 +42,7 @@ import static org.craftercms.commons.validation.annotations.param.EsapiValidatio
 import static org.craftercms.studio.controller.rest.v2.RequestConstants.*;
 import static org.craftercms.studio.controller.rest.v2.RequestMappingConstants.*;
 import static org.craftercms.studio.controller.rest.v2.ResultConstants.RESULT_KEY_AUDIT_LOG;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 @Validated
 @RestController
@@ -49,7 +50,7 @@ public class AuditController {
 
 	private AuditService auditService;
 
-	@GetMapping(API_2 + AUDIT)
+	@GetMapping(value = API_2 + AUDIT, produces = APPLICATION_JSON_VALUE)
 	public PaginatedResultList<AuditLog> getAuditLog(
 		@ValidSiteId
 		@RequestParam(value = REQUEST_PARAM_SITEID, required = false, defaultValue = "") String siteId,
@@ -88,7 +89,7 @@ public class AuditController {
 		return result;
 	}
 
-	@GetMapping(API_2 + AUDIT + PATH_PARAM_ID)
+	@GetMapping(value = API_2 + AUDIT + PATH_PARAM_ID, produces = APPLICATION_JSON_VALUE)
 	public ResultOne<AuditLog> getAuditLogEntry(@PathVariable(REQUEST_PARAM_ID) long auditLogId,
 						    @ValidSiteId
 						    @RequestParam(value = REQUEST_PARAM_SITEID, required = false, defaultValue = "") String siteId) throws SiteNotFoundException {

--- a/studio/src/main/java/org/craftercms/studio/controller/rest/v2/ConfigurationController.java
+++ b/studio/src/main/java/org/craftercms/studio/controller/rest/v2/ConfigurationController.java
@@ -44,6 +44,7 @@ import static org.craftercms.studio.controller.rest.v2.ResultConstants.RESULT_KE
 import static org.craftercms.studio.controller.rest.v2.ResultConstants.RESULT_KEY_HISTORY;
 import org.craftercms.studio.model.config.TranslationConfiguration;
 import static org.craftercms.studio.model.rest.ApiResponse.OK;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 import org.craftercms.studio.model.rest.ConfigurationHistory;
 import org.craftercms.studio.model.rest.Result;
 import org.craftercms.studio.model.rest.ResultOne;
@@ -98,7 +99,7 @@ public class ConfigurationController {
 		return result;
 	}
 
-	@PostMapping(WRITE_CONFIGURATION)
+	@PostMapping(value = WRITE_CONFIGURATION, consumes = APPLICATION_JSON_VALUE)
 	public Result writeConfiguration(@Validated @RequestBody WriteConfigurationRequest wcRequest)
 		throws ServiceLayerException, UserNotFoundException, AuthenticationException {
 		InputStream is = IOUtils.toInputStream(wcRequest.getContent(), UTF_8);

--- a/studio/src/main/java/org/craftercms/studio/controller/rest/v2/ConfigurationController.java
+++ b/studio/src/main/java/org/craftercms/studio/controller/rest/v2/ConfigurationController.java
@@ -71,7 +71,7 @@ public class ConfigurationController {
 		this.studioConfiguration = studioConfiguration;
 	}
 
-	@GetMapping(CLEAR_CACHE)
+	@GetMapping(value = CLEAR_CACHE, produces = APPLICATION_JSON_VALUE)
 	public Result clearCache(@ValidSiteId @RequestParam String siteId) {
 		configurationService.invalidateConfiguration(siteId);
 		var result = new Result();
@@ -79,7 +79,7 @@ public class ConfigurationController {
 		return result;
 	}
 
-	@GetMapping(GET_CONFIGURATION)
+	@GetMapping(value = GET_CONFIGURATION, produces = APPLICATION_JSON_VALUE)
 	@LogExecutionTime
 	public ResultOne<String> getConfiguration(@ValidSiteId @RequestParam(name = "siteId", required = true) String siteId,
 						  @EsapiValidatedParam(type = ALPHANUMERIC) @RequestParam(name = "module", required = true) String module,
@@ -99,7 +99,7 @@ public class ConfigurationController {
 		return result;
 	}
 
-	@PostMapping(value = WRITE_CONFIGURATION, consumes = APPLICATION_JSON_VALUE)
+	@PostMapping(value = WRITE_CONFIGURATION, consumes = APPLICATION_JSON_VALUE, produces = APPLICATION_JSON_VALUE)
 	public Result writeConfiguration(@Validated @RequestBody WriteConfigurationRequest wcRequest)
 		throws ServiceLayerException, UserNotFoundException, AuthenticationException {
 		InputStream is = IOUtils.toInputStream(wcRequest.getContent(), UTF_8);
@@ -115,7 +115,7 @@ public class ConfigurationController {
 		return result;
 	}
 
-	@GetMapping(GET_CONFIGURATION_HISTORY)
+	@GetMapping(value = GET_CONFIGURATION_HISTORY, produces = APPLICATION_JSON_VALUE)
 	public ResultOne<ConfigurationHistory> getConfigurationHistory(@ValidSiteId @RequestParam(name = "siteId", required = true) String siteId,
 								       @EsapiValidatedParam(type = ALPHANUMERIC) @RequestParam(name = "module", required = true) String module,
 								       @ValidConfigurationPath @RequestParam(name = "path", required = true) String path,
@@ -129,7 +129,7 @@ public class ConfigurationController {
 		return result;
 	}
 
-	@GetMapping(TRANSLATION)
+	@GetMapping(value = TRANSLATION, produces = APPLICATION_JSON_VALUE)
 	public ResultOne<TranslationConfiguration> getTranslationConfiguration(@ValidSiteId @RequestParam String siteId) throws ServiceLayerException {
 		ResultOne<TranslationConfiguration> result = new ResultOne<>();
 		result.setEntity(RESULT_KEY_CONFIG, configurationService.getTranslationConfiguration(siteId));

--- a/studio/src/main/java/org/craftercms/studio/controller/rest/v2/ContentController.java
+++ b/studio/src/main/java/org/craftercms/studio/controller/rest/v2/ContentController.java
@@ -123,7 +123,7 @@ public class ContentController {
 		return result;
 	}
 
-	@PostMapping(GET_DELETE_PACKAGE)
+	@PostMapping(value = GET_DELETE_PACKAGE, consumes = APPLICATION_JSON_VALUE)
 	public ResultOne<Map<String, Collection<LightItem>>> getDeletePackage(@RequestBody @Valid GetDeletePackageRequestBody request) throws SiteNotFoundException {
 		List<LightItem> childItems = contentService.getChildItems(request.getSiteId(), request.getPaths());
 		Collection<LightItem> dependentItems = dependencyService.getDependentPaths(request.getSiteId(), request.getPaths());
@@ -146,7 +146,7 @@ public class ContentController {
 		return result;
 	}
 
-	@PostMapping(value = GET_CHILDREN_BY_PATHS, produces = APPLICATION_JSON_VALUE)
+	@PostMapping(value = GET_CHILDREN_BY_PATHS, produces = APPLICATION_JSON_VALUE, consumes = APPLICATION_JSON_VALUE)
 	public Result getChildrenByPaths(@PathVariable @ValidSiteId String siteId, @Valid @RequestBody GetChildrenBulkRequest request)
 			throws ServiceLayerException, UserNotFoundException {
 		Map<String, PathParams> paramsMap = request.getPaths().stream()
@@ -170,7 +170,7 @@ public class ContentController {
 		return result;
 	}
 
-	@PostMapping(value = PASTE_ITEMS, produces = APPLICATION_JSON_VALUE)
+	@PostMapping(value = PASTE_ITEMS, produces = APPLICATION_JSON_VALUE, consumes = APPLICATION_JSON_VALUE)
 	public ResultList<String> pasteItems(@ValidSiteId @PathVariable String siteId,
 										 @Valid @RequestBody PasteRequest request) throws Exception {
 		var result = new ResultList<String>();
@@ -182,7 +182,7 @@ public class ContentController {
 		return result;
 	}
 
-	@PostMapping(value = DUPLICATE_ITEM, produces = APPLICATION_JSON_VALUE)
+	@PostMapping(value = DUPLICATE_ITEM, produces = APPLICATION_JSON_VALUE, consumes = APPLICATION_JSON_VALUE)
 	public ResultOne<String> duplicateItem(@Valid @RequestBody DuplicateRequest request) throws Exception {
 		var result = new ResultOne<String>();
 		result.setResponse(OK);
@@ -207,7 +207,7 @@ public class ContentController {
 		return result;
 	}
 
-	@PostMapping(value = SANDBOX_ITEMS_BY_PATH, produces = APPLICATION_JSON_VALUE)
+	@PostMapping(value = SANDBOX_ITEMS_BY_PATH, produces = APPLICATION_JSON_VALUE, consumes = APPLICATION_JSON_VALUE)
 	public GetContentItemsByPathResult getSandboxItemsByPath(@RequestBody @Valid GetSandboxItemsByPathRequestBody request)
 			throws ServiceLayerException, UserNotFoundException {
 		String siteId = request.getSiteId();
@@ -232,7 +232,7 @@ public class ContentController {
 		return result;
 	}
 
-	@PostMapping(ITEM_LOCK_BY_PATH)
+	@PostMapping(value = ITEM_LOCK_BY_PATH, consumes = APPLICATION_JSON_VALUE)
 	public Result itemLockByPath(@RequestBody @Valid LockItemByPathRequest request)
 			throws UserNotFoundException, ServiceLayerException {
 		contentService.lockContent(request.getSiteId(), request.getPath());
@@ -241,7 +241,7 @@ public class ContentController {
 		return result;
 	}
 
-	@PostMapping(ITEM_UNLOCK_BY_PATH)
+	@PostMapping(value = ITEM_UNLOCK_BY_PATH, consumes = APPLICATION_JSON_VALUE)
 	public Result itemUnlockByPath(@RequestBody @Valid UnlockItemByPathRequest request)
 			throws ContentNotFoundException, SiteNotFoundException, RepositoryException {
 		contentService.unlockContent(request.getSiteId(), request.getPath());
@@ -349,7 +349,7 @@ public class ContentController {
 		return result;
 	}
 
-	@PostMapping(REVERT)
+	@PostMapping(value = REVERT, consumes = APPLICATION_JSON_VALUE)
 	public Result revert(@ValidSiteId @PathVariable String siteId, @Valid @RequestBody RevertRequestBody revertRequestBody)
 			throws ServiceLayerException, UserNotFoundException, AuthenticationException {
 		contentService.revert(siteId, revertRequestBody.getPath(), revertRequestBody.getCommitId());
@@ -358,7 +358,7 @@ public class ContentController {
 		return result;
 	}
 
-	@PostMapping(FOLDER)
+	@PostMapping(value = FOLDER, consumes = APPLICATION_JSON_VALUE)
 	@ResponseStatus(HttpStatus.CREATED)
 	public Result createFolder(@ValidSiteId @PathVariable String siteId, @Valid @RequestBody CreateFolderRequestBody requestBody)
 			throws UserNotFoundException, ServiceLayerException, AuthenticationException {
@@ -382,7 +382,7 @@ public class ContentController {
 		return result;
 	}
 
-	@PostMapping(REORDER_ITEM)
+	@PostMapping(value = REORDER_ITEM, consumes = APPLICATION_JSON_VALUE)
 	public ResultOne<Double> reorderItem(@ValidSiteId @PathVariable String siteId, @Valid @RequestBody ReorderItemRequest request) throws ServiceLayerException {
 		ResultOne<Double> result = new ResultOne<>();
 		result.setEntity(RESULT_KEY_ORDER, contentService.reorderItem(siteId, request));

--- a/studio/src/main/java/org/craftercms/studio/controller/rest/v2/ContentController.java
+++ b/studio/src/main/java/org/craftercms/studio/controller/rest/v2/ContentController.java
@@ -113,7 +113,7 @@ public class ContentController {
 		return result;
 	}
 
-	@GetMapping(LIST_QUICK_CREATE_CONTENT)
+	@GetMapping(value = LIST_QUICK_CREATE_CONTENT, produces = APPLICATION_JSON_VALUE)
 	public ResultList<QuickCreateItem> listQuickCreateContent(@NotBlank @ValidSiteId @RequestParam(name = "siteId") String siteId)
 			throws ServiceLayerException {
 		List<QuickCreateItem> items = contentTypeService.getQuickCreatableContentTypes(siteId);
@@ -123,7 +123,7 @@ public class ContentController {
 		return result;
 	}
 
-	@PostMapping(value = GET_DELETE_PACKAGE, consumes = APPLICATION_JSON_VALUE)
+	@PostMapping(value = GET_DELETE_PACKAGE, consumes = APPLICATION_JSON_VALUE, produces = APPLICATION_JSON_VALUE)
 	public ResultOne<Map<String, Collection<LightItem>>> getDeletePackage(@RequestBody @Valid GetDeletePackageRequestBody request) throws SiteNotFoundException {
 		List<LightItem> childItems = contentService.getChildItems(request.getSiteId(), request.getPaths());
 		Collection<LightItem> dependentItems = dependencyService.getDependentPaths(request.getSiteId(), request.getPaths());
@@ -136,7 +136,7 @@ public class ContentController {
 		return result;
 	}
 
-	@PostMapping(value = DELETE, consumes = APPLICATION_JSON_VALUE)
+	@PostMapping(value = DELETE, consumes = APPLICATION_JSON_VALUE, produces = APPLICATION_JSON_VALUE)
 	public Result delete(@RequestBody @Validated DeleteRequestBody deleteRequestBody)
 			throws UserNotFoundException, ServiceLayerException, AuthenticationException {
 		UnwrappedResult<DeleteContentResult> result = UnwrappedResult.of(contentService.deleteContent(deleteRequestBody.getSiteId(),
@@ -232,7 +232,7 @@ public class ContentController {
 		return result;
 	}
 
-	@PostMapping(value = ITEM_LOCK_BY_PATH, consumes = APPLICATION_JSON_VALUE)
+	@PostMapping(value = ITEM_LOCK_BY_PATH, consumes = APPLICATION_JSON_VALUE, produces = APPLICATION_JSON_VALUE)
 	public Result itemLockByPath(@RequestBody @Valid LockItemByPathRequest request)
 			throws UserNotFoundException, ServiceLayerException {
 		contentService.lockContent(request.getSiteId(), request.getPath());
@@ -241,7 +241,7 @@ public class ContentController {
 		return result;
 	}
 
-	@PostMapping(value = ITEM_UNLOCK_BY_PATH, consumes = APPLICATION_JSON_VALUE)
+	@PostMapping(value = ITEM_UNLOCK_BY_PATH, consumes = APPLICATION_JSON_VALUE, produces = APPLICATION_JSON_VALUE)
 	public Result itemUnlockByPath(@RequestBody @Valid UnlockItemByPathRequest request)
 			throws ContentNotFoundException, SiteNotFoundException, RepositoryException {
 		contentService.unlockContent(request.getSiteId(), request.getPath());
@@ -265,7 +265,7 @@ public class ContentController {
 				.body(resource);
 	}
 
-	@PostMapping(value = SITE_ID, consumes = APPLICATION_JSON_VALUE)
+	@PostMapping(value = SITE_ID, consumes = APPLICATION_JSON_VALUE, produces = APPLICATION_JSON_VALUE)
 	public ResponseEntity<Result> write(@PathVariable @ValidSiteId String siteId,
 										@Valid @RequestBody WriteContentRequest writeContentRequest)
 			throws ServiceLayerException, UserNotFoundException, AuthenticationException {
@@ -273,7 +273,7 @@ public class ContentController {
 				writeContentRequest.getComment());
 	}
 
-	@PutMapping(value = SITE_ID, consumes = MULTIPART_FORM_DATA_VALUE)
+	@PutMapping(value = SITE_ID, consumes = MULTIPART_FORM_DATA_VALUE, produces = APPLICATION_JSON_VALUE)
 	public ResponseEntity<Result> upload(@PathVariable @ValidSiteId String siteId,
 										 @RequestParam MultipartFile file,
 										 @NotEmpty @ValidNewContentPath @RequestPart(REQUEST_PARAM_PATH) String path,
@@ -300,7 +300,7 @@ public class ContentController {
 				.body(result);
 	}
 
-	@PostMapping(value = RENAME, consumes = APPLICATION_JSON_VALUE)
+	@PostMapping(value = RENAME, consumes = APPLICATION_JSON_VALUE, produces = APPLICATION_JSON_VALUE)
 	public Result rename(@Valid @RequestBody RenameRequestBody renameRequestBody)
 			throws AuthenticationException, UserNotFoundException, ServiceLayerException, ValidationException {
 		contentService.renameContent(renameRequestBody.getSiteId(), renameRequestBody.getPath(), renameRequestBody.getName());
@@ -309,7 +309,7 @@ public class ContentController {
 		return result;
 	}
 
-	@PostMapping(value = MOVE, consumes = APPLICATION_JSON_VALUE)
+	@PostMapping(value = MOVE, consumes = APPLICATION_JSON_VALUE, produces = APPLICATION_JSON_VALUE)
 	public Result move(@ValidSiteId @PathVariable String siteId, @Valid @RequestBody MoveRequestBody moveRequestBody)
 			throws AuthenticationException, UserNotFoundException, ServiceLayerException, ValidationException {
 		UnwrappedResult<WriteContentResult> result = UnwrappedResult.of(
@@ -319,7 +319,7 @@ public class ContentController {
 		return result;
 	}
 
-	@PostMapping(value = MOVE_AND_UPDATE, consumes = APPLICATION_JSON_VALUE)
+	@PostMapping(value = MOVE_AND_UPDATE, consumes = APPLICATION_JSON_VALUE, produces = APPLICATION_JSON_VALUE)
 	public Result moveAndUpdate(@ValidSiteId @PathVariable String siteId, @Valid @RequestBody MoveAndUpdateRequestBody requestBody)
 			throws AuthenticationException, ServiceLayerException, UserNotFoundException {
 		UnwrappedResult<WriteContentResult> result = UnwrappedResult.of(
@@ -329,7 +329,7 @@ public class ContentController {
 		return result;
 	}
 
-	@GetMapping(value = ITEM_HISTORY)
+	@GetMapping(value = ITEM_HISTORY, produces = APPLICATION_JSON_VALUE)
 	public ResultList<ItemVersion> getHistory(@ValidSiteId @RequestParam(value = REQUEST_PARAM_SITEID) String siteId,
 											  @ValidExistingContentPath @RequestParam(value = REQUEST_PARAM_PATH) String path) throws ServiceLayerException {
 		ResultList<ItemVersion> result = new ResultList<>();
@@ -339,7 +339,7 @@ public class ContentController {
 		return result;
 	}
 
-	@GetMapping(SITE_HISTORY)
+	@GetMapping(value = SITE_HISTORY, produces = APPLICATION_JSON_VALUE)
 	public ResultList<RepositoryVersion> history(@ValidSiteId @PathVariable String siteId,
 												 @NotEmpty @RequestParam(defaultValue = Constants.HEAD) String start,
 												 @Positive @RequestParam(defaultValue = "10") int limit) throws ServiceLayerException {
@@ -349,7 +349,7 @@ public class ContentController {
 		return result;
 	}
 
-	@PostMapping(value = REVERT, consumes = APPLICATION_JSON_VALUE)
+	@PostMapping(value = REVERT, consumes = APPLICATION_JSON_VALUE, produces = APPLICATION_JSON_VALUE)
 	public Result revert(@ValidSiteId @PathVariable String siteId, @Valid @RequestBody RevertRequestBody revertRequestBody)
 			throws ServiceLayerException, UserNotFoundException, AuthenticationException {
 		contentService.revert(siteId, revertRequestBody.getPath(), revertRequestBody.getCommitId());
@@ -358,7 +358,7 @@ public class ContentController {
 		return result;
 	}
 
-	@PostMapping(value = FOLDER, consumes = APPLICATION_JSON_VALUE)
+	@PostMapping(value = FOLDER, consumes = APPLICATION_JSON_VALUE, produces = APPLICATION_JSON_VALUE)
 	@ResponseStatus(HttpStatus.CREATED)
 	public Result createFolder(@ValidSiteId @PathVariable String siteId, @Valid @RequestBody CreateFolderRequestBody requestBody)
 			throws UserNotFoundException, ServiceLayerException, AuthenticationException {
@@ -373,7 +373,7 @@ public class ContentController {
 		return result;
 	}
 
-	@GetMapping(GET_ITEMS_ORDER)
+	@GetMapping(value = GET_ITEMS_ORDER, produces = APPLICATION_JSON_VALUE)
 	public ResultList<ItemOrder> getItemsOrder(@ValidSiteId @PathVariable String siteId, @NotEmpty @ValidExistingContentPath @RequestParam String parentPath) throws ServiceLayerException {
 		ResultList<ItemOrder> result = new ResultList<>();
 		List<ItemOrder> itemsOrder = contentService.getItemsOrder(siteId, parentPath);
@@ -382,7 +382,7 @@ public class ContentController {
 		return result;
 	}
 
-	@PostMapping(value = REORDER_ITEM, consumes = APPLICATION_JSON_VALUE)
+	@PostMapping(value = REORDER_ITEM, consumes = APPLICATION_JSON_VALUE, produces = APPLICATION_JSON_VALUE)
 	public ResultOne<Double> reorderItem(@ValidSiteId @PathVariable String siteId, @Valid @RequestBody ReorderItemRequest request) throws ServiceLayerException {
 		ResultOne<Double> result = new ResultOne<>();
 		result.setEntity(RESULT_KEY_ORDER, contentService.reorderItem(siteId, request));

--- a/studio/src/main/java/org/craftercms/studio/controller/rest/v2/ContentTypeController.java
+++ b/studio/src/main/java/org/craftercms/studio/controller/rest/v2/ContentTypeController.java
@@ -60,7 +60,7 @@ public class ContentTypeController {
 		this.contentTypeService = contentTypeService;
 	}
 
-	@GetMapping(USAGE)
+	@GetMapping(value = USAGE, produces = APPLICATION_JSON_VALUE)
 	public ResultOne<Object> getContentTypeUsage(@ValidSiteId @PathVariable String siteId,
 												 @ValidConfigurationPath @RequestParam String contentType)
 			throws Exception {
@@ -86,7 +86,7 @@ public class ContentTypeController {
 		return getResourceResponse(resource.getKey(), resource.getValue());
 	}
 
-	@GetMapping
+	@GetMapping(produces = APPLICATION_JSON_VALUE)
 	public ResultList<ContentType> getContentTypes(@ValidSiteId @PathVariable String siteId,
 												   @ValidConfigurationPath @RequestParam(required = false) String contentTypeId) throws ServiceLayerException {
 		var result = new ResultList<ContentType>();
@@ -102,7 +102,7 @@ public class ContentTypeController {
 		return result;
 	}
 
-	@GetMapping(ALLOWED_TYPES)
+	@GetMapping(value = ALLOWED_TYPES, produces = APPLICATION_JSON_VALUE)
 	public ResultList<String> getAllowedContentTypes(@ValidSiteId @PathVariable String siteId, @ValidExistingContentPath @RequestParam String path) throws ServiceLayerException {
 		ResultList<String> result = new ResultList<>();
 		result.setResponse(OK);
@@ -110,7 +110,7 @@ public class ContentTypeController {
 		return result;
 	}
 
-	@DeleteMapping(consumes = APPLICATION_JSON_VALUE)
+	@DeleteMapping(consumes = APPLICATION_JSON_VALUE, produces = APPLICATION_JSON_VALUE)
 	public Result deleteContentType(@ValidSiteId @PathVariable String siteId, @RequestBody @Valid DeleteContentTypeRequest request)
 			throws ServiceLayerException, AuthenticationException, UserNotFoundException {
 		contentTypeService.deleteContentType(siteId, request.getContentType(),

--- a/studio/src/main/java/org/craftercms/studio/controller/rest/v2/ContentTypeController.java
+++ b/studio/src/main/java/org/craftercms/studio/controller/rest/v2/ContentTypeController.java
@@ -47,6 +47,7 @@ import static org.craftercms.studio.controller.rest.v2.RequestMappingConstants.*
 import static org.craftercms.studio.controller.rest.v2.ResultConstants.*;
 import static org.craftercms.studio.model.rest.ApiResponse.DELETED;
 import static org.craftercms.studio.model.rest.ApiResponse.OK;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 @Validated
 @RestController
@@ -109,7 +110,7 @@ public class ContentTypeController {
 		return result;
 	}
 
-	@DeleteMapping
+	@DeleteMapping(consumes = APPLICATION_JSON_VALUE)
 	public Result deleteContentType(@ValidSiteId @PathVariable String siteId, @RequestBody @Valid DeleteContentTypeRequest request)
 			throws ServiceLayerException, AuthenticationException, UserNotFoundException {
 		contentTypeService.deleteContentType(siteId, request.getContentType(),

--- a/studio/src/main/java/org/craftercms/studio/controller/rest/v2/DependencyController.java
+++ b/studio/src/main/java/org/craftercms/studio/controller/rest/v2/DependencyController.java
@@ -37,6 +37,7 @@ import java.util.Map;
 import static org.craftercms.studio.controller.rest.v2.RequestMappingConstants.*;
 import static org.craftercms.studio.controller.rest.v2.ResultConstants.*;
 import static org.craftercms.studio.model.rest.ApiResponse.OK;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 @Validated
 @RestController
@@ -50,7 +51,7 @@ public class DependencyController {
 		this.dependencyService = dependencyService;
 	}
 
-	@PostMapping(PATH_PARAM_SITE + PUBLISH_DEPENDENCIES)
+	@PostMapping(value = PATH_PARAM_SITE + PUBLISH_DEPENDENCIES, consumes = APPLICATION_JSON_VALUE)
 	public ResultOne<Map<String, Collection<LightItem>>> getPublishDependencies(@PathVariable @ValidSiteId String site,
 																				@RequestBody @Valid GetPublishDependenciesRequestBody request) throws SiteNotFoundException {
 		Collection<LightItem> softDeps = dependencyService.getSoftDependencies(site, request.getPaths());
@@ -67,7 +68,7 @@ public class DependencyController {
 		return result;
 	}
 
-	@PostMapping(PATH_PARAM_SITE + DEPENDENT_ITEMS)
+	@PostMapping(value = PATH_PARAM_SITE + DEPENDENT_ITEMS, consumes = APPLICATION_JSON_VALUE)
 	public ResultOne<Collection<LightItem>> getDependentItems(@PathVariable @ValidSiteId String site,
 															  @RequestBody @Valid GetDependentsRequestBody request)
 			throws ServiceLayerException {
@@ -78,7 +79,7 @@ public class DependencyController {
 		return result;
 	}
 
-	@PostMapping(PATH_PARAM_SITE + DEPENDENCIES)
+	@PostMapping(value = PATH_PARAM_SITE + DEPENDENCIES, consumes = APPLICATION_JSON_VALUE)
 	public ResultOne<Collection<LightItem>> getDependencies(@PathVariable @ValidSiteId String site,
 															@RequestBody @Valid GetDependenciesRequestBody request)
 			throws ServiceLayerException {

--- a/studio/src/main/java/org/craftercms/studio/controller/rest/v2/DependencyController.java
+++ b/studio/src/main/java/org/craftercms/studio/controller/rest/v2/DependencyController.java
@@ -51,7 +51,7 @@ public class DependencyController {
 		this.dependencyService = dependencyService;
 	}
 
-	@PostMapping(value = PATH_PARAM_SITE + PUBLISH_DEPENDENCIES, consumes = APPLICATION_JSON_VALUE)
+	@PostMapping(value = PATH_PARAM_SITE + PUBLISH_DEPENDENCIES, consumes = APPLICATION_JSON_VALUE, produces = APPLICATION_JSON_VALUE)
 	public ResultOne<Map<String, Collection<LightItem>>> getPublishDependencies(@PathVariable @ValidSiteId String site,
 																				@RequestBody @Valid GetPublishDependenciesRequestBody request) throws SiteNotFoundException {
 		Collection<LightItem> softDeps = dependencyService.getSoftDependencies(site, request.getPaths());
@@ -68,7 +68,7 @@ public class DependencyController {
 		return result;
 	}
 
-	@PostMapping(value = PATH_PARAM_SITE + DEPENDENT_ITEMS, consumes = APPLICATION_JSON_VALUE)
+	@PostMapping(value = PATH_PARAM_SITE + DEPENDENT_ITEMS, consumes = APPLICATION_JSON_VALUE, produces = APPLICATION_JSON_VALUE)
 	public ResultOne<Collection<LightItem>> getDependentItems(@PathVariable @ValidSiteId String site,
 															  @RequestBody @Valid GetDependentsRequestBody request)
 			throws ServiceLayerException {
@@ -79,7 +79,7 @@ public class DependencyController {
 		return result;
 	}
 
-	@PostMapping(value = PATH_PARAM_SITE + DEPENDENCIES, consumes = APPLICATION_JSON_VALUE)
+	@PostMapping(value = PATH_PARAM_SITE + DEPENDENCIES, consumes = APPLICATION_JSON_VALUE, produces = APPLICATION_JSON_VALUE)
 	public ResultOne<Collection<LightItem>> getDependencies(@PathVariable @ValidSiteId String site,
 															@RequestBody @Valid GetDependenciesRequestBody request)
 			throws ServiceLayerException {

--- a/studio/src/main/java/org/craftercms/studio/controller/rest/v2/GroupsController.java
+++ b/studio/src/main/java/org/craftercms/studio/controller/rest/v2/GroupsController.java
@@ -71,7 +71,7 @@ public class GroupsController {
 	 * @param sort    sort parameter
 	 * @return Response containing list of groups
 	 */
-	@GetMapping
+	@GetMapping(produces = MediaType.APPLICATION_JSON_VALUE)
 	public PaginatedResultList<Group> getAllGroups(
 		@RequestParam(value = REQUEST_PARAM_KEYWORD, required = false) String keyword,
 		@PositiveOrZero @RequestParam(value = REQUEST_PARAM_OFFSET, required = false, defaultValue = "0") int offset,
@@ -98,7 +98,7 @@ public class GroupsController {
 	 * @return Response object
 	 */
 	@ResponseStatus(HttpStatus.CREATED)
-	@PostMapping(consumes = MediaType.APPLICATION_JSON_VALUE)
+	@PostMapping(consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
 	public ResultOne<Group> createGroup(@Valid @RequestBody Group group)
 		throws GroupAlreadyExistsException, ServiceLayerException, AuthenticationException {
 		Group newGroup =
@@ -115,7 +115,7 @@ public class GroupsController {
 	 * @param updateRequest {@link UpdateGroupRequest} to update
 	 * @return Response object
 	 */
-	@PatchMapping(consumes = MediaType.APPLICATION_JSON_VALUE)
+	@PatchMapping(consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
 	public ResultOne<Group> updateGroup(@Valid @RequestBody UpdateGroupRequest updateRequest)
 		throws ServiceLayerException, GroupNotFoundException, AuthenticationException, GroupExternallyManagedException {
 		Group group = buildGroup(updateRequest);
@@ -140,7 +140,7 @@ public class GroupsController {
 	 * @param groupIds Group identifier
 	 * @return Response object
 	 */
-	@DeleteMapping
+	@DeleteMapping(produces = MediaType.APPLICATION_JSON_VALUE)
 	public Result deleteGroups(@RequestParam(REQUEST_PARAM_ID) List<Long> groupIds)
 		throws ServiceLayerException, GroupNotFoundException, AuthenticationException, GroupExternallyManagedException {
 		groupService.deleteGroup(groupIds);
@@ -155,7 +155,7 @@ public class GroupsController {
 	 * @param groupId Group identifier
 	 * @return Response containing requested group
 	 */
-	@GetMapping(PATH_PARAM_ID)
+	@GetMapping(value = PATH_PARAM_ID, produces = MediaType.APPLICATION_JSON_VALUE)
 	public ResultOne<Group> getGroup(@PathVariable(REQUEST_PARAM_ID) int groupId)
 		throws ServiceLayerException, GroupNotFoundException {
 		Group group = groupService.getGroup(groupId);
@@ -171,7 +171,7 @@ public class GroupsController {
 	 * @param groupName Group name
 	 * @return Response containing requested group
 	 */
-	@GetMapping(PATH_PARAM_GROUP_NAME)
+	@GetMapping(value = PATH_PARAM_GROUP_NAME, produces = MediaType.APPLICATION_JSON_VALUE)
 	public ResultOne<Group> getGroupByName(@PathVariable(REQUEST_GROUP_NAME) String groupName)
 		throws ServiceLayerException, GroupNotFoundException {
 		Group group = groupService.getGroupByName(groupName);
@@ -190,7 +190,7 @@ public class GroupsController {
 	 * @param sort    Sort order
 	 * @return Response containing list od users
 	 */
-	@GetMapping(PATH_PARAM_ID + MEMBERS)
+	@GetMapping(value = PATH_PARAM_ID + MEMBERS, produces = MediaType.APPLICATION_JSON_VALUE)
 	public PaginatedResultList<UserResponse> getGroupMembers(
 		@PathVariable(REQUEST_PARAM_ID) int groupId,
 		@PositiveOrZero @RequestParam(value = REQUEST_PARAM_OFFSET, required = false, defaultValue = "0") int offset,
@@ -218,7 +218,7 @@ public class GroupsController {
 	 * @param addGroupMembers Add members request body (json representation)
 	 * @return Response object
 	 */
-	@PostMapping(value = PATH_PARAM_ID + MEMBERS, consumes = MediaType.APPLICATION_JSON_VALUE)
+	@PostMapping(value = PATH_PARAM_ID + MEMBERS, consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
 	public ResultList<UserResponse> addGroupMembers(@PathVariable(REQUEST_PARAM_ID) int groupId,
 							@RequestBody AddGroupMembers addGroupMembers)
 		throws ServiceLayerException, UserNotFoundException, GroupNotFoundException, AuthenticationException {
@@ -242,7 +242,7 @@ public class GroupsController {
 	 * @param usernames List of usernames
 	 * @return Response object
 	 */
-	@DeleteMapping(PATH_PARAM_ID + MEMBERS)
+	@DeleteMapping(value = PATH_PARAM_ID + MEMBERS, produces = MediaType.APPLICATION_JSON_VALUE)
 	public Result removeGroupMembers(
 		@PathVariable(REQUEST_PARAM_ID) int groupId,
 		@RequestParam(value = REQUEST_PARAM_USER_ID, required = false) List<Long> userIds,

--- a/studio/src/main/java/org/craftercms/studio/controller/rest/v2/LoggerController.java
+++ b/studio/src/main/java/org/craftercms/studio/controller/rest/v2/LoggerController.java
@@ -54,7 +54,7 @@ public class LoggerController {
 		this.loggerService = logService;
 	}
 
-	@GetMapping
+	@GetMapping(produces = APPLICATION_JSON_VALUE)
 	public ResultList<LoggerConfig> getLoggers() throws ServiceLayerException {
 		ResultList<LoggerConfig> result = new ResultList<>();
 		result.setResponse(ApiResponse.OK);
@@ -63,7 +63,7 @@ public class LoggerController {
 	}
 
 	@Valid
-	@PostMapping(value = LOGGER_LEVEL, consumes = APPLICATION_JSON_VALUE)
+	@PostMapping(value = LOGGER_LEVEL, consumes = APPLICATION_JSON_VALUE, produces = APPLICATION_JSON_VALUE)
 	public ResultOne<LoggerConfig> setLoggerLevel(@Valid @RequestBody LoggerConfigRequest loggerConfig) throws ServiceLayerException {
 		ResultOne<LoggerConfig> result = new ResultOne<>();
 		result.setResponse(ApiResponse.OK);

--- a/studio/src/main/java/org/craftercms/studio/controller/rest/v2/LoggerController.java
+++ b/studio/src/main/java/org/craftercms/studio/controller/rest/v2/LoggerController.java
@@ -32,6 +32,7 @@ import java.beans.ConstructorProperties;
 import static org.craftercms.studio.controller.rest.v2.LoggerController.ROOT_URL;
 import static org.craftercms.studio.controller.rest.v2.ResultConstants.RESULT_KEY_RESULT;
 import static org.craftercms.studio.controller.rest.v2.ResultConstants.RESULT_KEY_RESULTS;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 /**
  * REST controller that provides access to Logger related operations.
@@ -62,7 +63,7 @@ public class LoggerController {
 	}
 
 	@Valid
-	@PostMapping(value = LOGGER_LEVEL)
+	@PostMapping(value = LOGGER_LEVEL, consumes = APPLICATION_JSON_VALUE)
 	public ResultOne<LoggerConfig> setLoggerLevel(@Valid @RequestBody LoggerConfigRequest loggerConfig) throws ServiceLayerException {
 		ResultOne<LoggerConfig> result = new ResultOne<>();
 		result.setResponse(ApiResponse.OK);

--- a/studio/src/main/java/org/craftercms/studio/controller/rest/v2/MarketplaceController.java
+++ b/studio/src/main/java/org/craftercms/studio/controller/rest/v2/MarketplaceController.java
@@ -44,6 +44,7 @@ import java.util.Map;
 import static org.craftercms.commons.validation.annotations.param.EsapiValidationType.SEARCH_KEYWORDS;
 import static org.craftercms.studio.controller.rest.v2.ResultConstants.RESULT_KEY_ITEMS;
 import static org.craftercms.studio.controller.rest.v2.ResultConstants.RESULT_KEY_PLUGINS;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 /**
  * REST controller that provides access to Marketplace operations
@@ -93,7 +94,7 @@ public class MarketplaceController {
 		return result;
 	}
 
-	@PostMapping("/install")
+	@PostMapping(value = "/install", consumes = APPLICATION_JSON_VALUE)
 	public Result installPlugin(@Valid @RequestBody InstallPluginRequest request) throws MarketplaceException {
 		marketplaceService.installPlugin(request.getSiteId(), request.getPluginId(), request.getPluginVersion(),
 			request.getParameters());
@@ -112,7 +113,7 @@ public class MarketplaceController {
 		return result;
 	}
 
-	@PostMapping("/remove")
+	@PostMapping(value = "/remove", consumes = APPLICATION_JSON_VALUE)
 	public Result removePlugin(@Valid @RequestBody RemovePluginRequest request) throws ServiceLayerException {
 		marketplaceService.removePlugin(request.getSiteId(), request.getPluginId(), request.isForce());
 
@@ -159,7 +160,7 @@ public class MarketplaceController {
 
 	}
 
-	@PostMapping("copy")
+	@PostMapping(value = "copy", consumes = APPLICATION_JSON_VALUE)
 	public Result copyPlugin(@Valid @RequestBody CopyPluginRequest request) throws MarketplaceException {
 		marketplaceService.copyPlugin(request.getSiteId(), request.getPath(), request.getParameters());
 

--- a/studio/src/main/java/org/craftercms/studio/controller/rest/v2/MarketplaceController.java
+++ b/studio/src/main/java/org/craftercms/studio/controller/rest/v2/MarketplaceController.java
@@ -65,7 +65,7 @@ public class MarketplaceController {
 	}
 
 	@SuppressWarnings("unchecked")
-	@GetMapping("/search")
+	@GetMapping(value = "/search", produces = APPLICATION_JSON_VALUE)
 	public PaginatedResultList<Map<String, Object>> searchPlugins(@RequestParam(required = false) String type,
 								      @EsapiValidatedParam(type = SEARCH_KEYWORDS)
 								      @RequestParam(required = false) String keywords,
@@ -86,7 +86,7 @@ public class MarketplaceController {
 		return result;
 	}
 
-	@GetMapping("/installed")
+	@GetMapping(value = "/installed", produces = APPLICATION_JSON_VALUE)
 	public ResultList<PluginRecord> getInstalledPlugins(@RequestParam @ValidSiteId String siteId) throws MarketplaceException {
 		ResultList<PluginRecord> result = new ResultList<>();
 		result.setResponse(ApiResponse.OK);
@@ -94,7 +94,7 @@ public class MarketplaceController {
 		return result;
 	}
 
-	@PostMapping(value = "/install", consumes = APPLICATION_JSON_VALUE)
+	@PostMapping(value = "/install", consumes = APPLICATION_JSON_VALUE, produces = APPLICATION_JSON_VALUE)
 	public Result installPlugin(@Valid @RequestBody InstallPluginRequest request) throws MarketplaceException {
 		marketplaceService.installPlugin(request.getSiteId(), request.getPluginId(), request.getPluginVersion(),
 			request.getParameters());
@@ -104,7 +104,7 @@ public class MarketplaceController {
 		return result;
 	}
 
-	@GetMapping("/usage")
+	@GetMapping(value = "/usage", produces = APPLICATION_JSON_VALUE)
 	public ResultList<String> getDependantItems(@RequestParam @ValidSiteId String siteId, @RequestParam String pluginId)
 		throws ServiceLayerException {
 		ResultList<String> result = new ResultList<>();
@@ -113,7 +113,7 @@ public class MarketplaceController {
 		return result;
 	}
 
-	@PostMapping(value = "/remove", consumes = APPLICATION_JSON_VALUE)
+	@PostMapping(value = "/remove", consumes = APPLICATION_JSON_VALUE, produces = APPLICATION_JSON_VALUE)
 	public Result removePlugin(@Valid @RequestBody RemovePluginRequest request) throws ServiceLayerException {
 		marketplaceService.removePlugin(request.getSiteId(), request.getPluginId(), request.isForce());
 
@@ -160,7 +160,7 @@ public class MarketplaceController {
 
 	}
 
-	@PostMapping(value = "copy", consumes = APPLICATION_JSON_VALUE)
+	@PostMapping(value = "copy", consumes = APPLICATION_JSON_VALUE, produces = APPLICATION_JSON_VALUE)
 	public Result copyPlugin(@Valid @RequestBody CopyPluginRequest request) throws MarketplaceException {
 		marketplaceService.copyPlugin(request.getSiteId(), request.getPath(), request.getParameters());
 

--- a/studio/src/main/java/org/craftercms/studio/controller/rest/v2/ModelController.java
+++ b/studio/src/main/java/org/craftercms/studio/controller/rest/v2/ModelController.java
@@ -23,6 +23,7 @@ import org.craftercms.studio.api.v2.annotation.logging.LogExecutionTime;
 import org.craftercms.studio.api.v2.service.content.ContentTypeService;
 import org.craftercms.studio.model.contentType.ModelDefinitions;
 import static org.craftercms.studio.model.rest.ApiResponse.OK;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -40,7 +41,7 @@ public class ModelController {
 		this.contentTypeService = contentTypeService;
 	}
 
-	@PostMapping("/{siteId}/definitions")
+	@PostMapping(value = "/{siteId}/definitions", produces = APPLICATION_JSON_VALUE)
 	@LogExecutionTime
 	public ModelDefinitions getModelDefinitions(@ValidSiteId @PathVariable("siteId") String siteId) throws ServiceLayerException {
 		ModelDefinitions result = new ModelDefinitions(contentTypeService.getAllModelDefinitions(siteId));

--- a/studio/src/main/java/org/craftercms/studio/controller/rest/v2/MonitoringController.java
+++ b/studio/src/main/java/org/craftercms/studio/controller/rest/v2/MonitoringController.java
@@ -64,7 +64,7 @@ public class MonitoringController extends ManagementTokenAware {
 		this.monitorService = monitorService;
 	}
 
-	@GetMapping(value = ROOT_URL + MEMORY_URL)
+	@GetMapping(value = ROOT_URL + MEMORY_URL, produces = APPLICATION_JSON_VALUE)
 	public ResultOne<MemoryInfo> getCurrentMemory(@RequestParam(name = "token") String token)
 			throws InvalidManagementTokenException, InvalidParametersException {
 		validateToken(token, true);
@@ -74,7 +74,7 @@ public class MonitoringController extends ManagementTokenAware {
 		return result;
 	}
 
-	@GetMapping(value = ROOT_URL + STATUS_URL)
+	@GetMapping(value = ROOT_URL + STATUS_URL, produces = APPLICATION_JSON_VALUE)
 	public ResultOne<StatusInfo> getCurrentStatus(@RequestParam(name = "token") String token)
 			throws InvalidManagementTokenException, InvalidParametersException {
 		validateToken(token, true);
@@ -84,7 +84,7 @@ public class MonitoringController extends ManagementTokenAware {
 		return result;
 	}
 
-	@GetMapping(value = ROOT_URL + VERSION_URL)
+	@GetMapping(value = ROOT_URL + VERSION_URL, produces = APPLICATION_JSON_VALUE)
 	public ResultOne<VersionInfo> getCurrentVersion(@RequestParam(name = "token", required = false) String token)
 			throws InvalidManagementTokenException, IOException, InvalidParametersException {
 		validateToken(token);
@@ -94,7 +94,7 @@ public class MonitoringController extends ManagementTokenAware {
 		return result;
 	}
 
-	@GetMapping(value = ROOT_URL + SYSINFO_URL)
+	@GetMapping(value = ROOT_URL + SYSINFO_URL, produces = APPLICATION_JSON_VALUE)
 	public ResultOne<SysInfo> getCurrentSysInfo(@RequestParam(name = REQUEST_PARAM_TOKEN) String token)
 			throws InvalidManagementTokenException, IOException, InvalidParametersException {
 		validateToken(token, true);

--- a/studio/src/main/java/org/craftercms/studio/controller/rest/v2/PluginController.java
+++ b/studio/src/main/java/org/craftercms/studio/controller/rest/v2/PluginController.java
@@ -46,6 +46,7 @@ import static org.apache.commons.io.FilenameUtils.removeExtension;
 import static org.apache.commons.lang3.StringUtils.removeStart;
 import static org.craftercms.studio.controller.rest.v2.ResultConstants.RESULT_KEY_RESULT;
 import static org.craftercms.studio.model.rest.ApiResponse.OK;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 /**
  * Controller that executes Rest scripts from plugins
@@ -80,7 +81,7 @@ public class PluginController extends ManagementTokenAware {
 		return result;
 	}
 
-	@PostMapping("/write_configuration")
+	@PostMapping(value = "/write_configuration", consumes = APPLICATION_JSON_VALUE)
 	public Result writeConfiguration(@Valid @RequestBody WriteConfigurationRequest request)
 		throws UserNotFoundException, ServiceLayerException, AuthenticationException {
 		marketplaceService.writePluginConfiguration(request.getSiteId(), request.getPluginId(), request.getContent());

--- a/studio/src/main/java/org/craftercms/studio/controller/rest/v2/PluginController.java
+++ b/studio/src/main/java/org/craftercms/studio/controller/rest/v2/PluginController.java
@@ -71,7 +71,7 @@ public class PluginController extends ManagementTokenAware {
 		this.marketplaceService = marketplaceService;
 	}
 
-	@GetMapping("/get_configuration")
+	@GetMapping(value = "/get_configuration", produces = APPLICATION_JSON_VALUE)
 	public ResultOne<String> getPluginConfiguration(@ValidSiteId String siteId, String pluginId) throws ServiceLayerException {
 		String content = marketplaceService.getPluginConfigurationAsString(siteId, pluginId);
 
@@ -81,7 +81,7 @@ public class PluginController extends ManagementTokenAware {
 		return result;
 	}
 
-	@PostMapping(value = "/write_configuration", consumes = APPLICATION_JSON_VALUE)
+	@PostMapping(value = "/write_configuration", consumes = APPLICATION_JSON_VALUE, produces = APPLICATION_JSON_VALUE)
 	public Result writeConfiguration(@Valid @RequestBody WriteConfigurationRequest request)
 		throws UserNotFoundException, ServiceLayerException, AuthenticationException {
 		marketplaceService.writePluginConfiguration(request.getSiteId(), request.getPluginId(), request.getContent());
@@ -94,7 +94,7 @@ public class PluginController extends ManagementTokenAware {
 	/**
 	 * Reloads the groovy classes for the given site
 	 */
-	@GetMapping("/script/reload")
+	@GetMapping(value = "/script/reload", produces = APPLICATION_JSON_VALUE)
 	public Result reloadClasses(@ValidSiteId @RequestParam String siteId, @RequestParam String token)
 		throws InvalidParametersException, InvalidManagementTokenException {
 		validateToken(token);
@@ -110,7 +110,7 @@ public class PluginController extends ManagementTokenAware {
 	/**
 	 * Executes a rest script for the given site
 	 */
-	@RequestMapping("/script/**")
+	@RequestMapping(value = "/script/**", produces = APPLICATION_JSON_VALUE)
 	public ResultOne<Object> runScript(@ValidSiteId @RequestParam String siteId, HttpServletRequest request, HttpServletResponse response)
 		throws ResourceException, ScriptException, ConfigurationException {
 		// No better way to do this for now, later can be replaced by "/script/{*scriptUrl}"

--- a/studio/src/main/java/org/craftercms/studio/controller/rest/v2/PublishController.java
+++ b/studio/src/main/java/org/craftercms/studio/controller/rest/v2/PublishController.java
@@ -78,7 +78,7 @@ public class PublishController {
 		this.sitesService = sitesService;
 	}
 
-	@GetMapping(PATH_PARAM_SITE + PACKAGES)
+	@GetMapping(value = PATH_PARAM_SITE + PACKAGES, produces = APPLICATION_JSON_VALUE)
 	public PaginatedResultList<PublishPackage> getPublishPackages(@ValidSiteId @PathVariable String site,
 								      @EsapiValidatedParam(type = ALPHANUMERIC) @Size(max = 20)
 									  @Pattern(regexp = ALPHANUMERIC_LOWERCASE_PATTERN)
@@ -115,7 +115,7 @@ public class PublishController {
 		return result;
 	}
 
-	@GetMapping(PATH_PARAM_SITE + PACKAGE + PATH_PARAM_PACKAGE)
+	@GetMapping(value = PATH_PARAM_SITE + PACKAGE + PATH_PARAM_PACKAGE, produces = APPLICATION_JSON_VALUE)
 	public GetPackageResult getPublishPackage(@PathVariable @ValidSiteId String site,
 							   @PathVariable @Positive long packageId)
 		throws ServiceLayerException, UserNotFoundException {
@@ -126,7 +126,7 @@ public class PublishController {
 		return result;
 	}
 
-	@PostMapping(value = PATH_PARAM_SITE + PACKAGE + PATH_PARAM_PACKAGE, consumes = APPLICATION_JSON_VALUE)
+	@PostMapping(value = PATH_PARAM_SITE + PACKAGE + PATH_PARAM_PACKAGE, consumes = APPLICATION_JSON_VALUE, produces = APPLICATION_JSON_VALUE)
 	public Result updatePublishPackage(@PathVariable @ValidSiteId String site,
 			@PathVariable @Positive long packageId, @Validated @RequestBody UpdatePackageRequest request)
 			throws InvalidPackageStateException, SiteNotFoundException, AuthenticationException {
@@ -137,7 +137,7 @@ public class PublishController {
 		return result;
 	}
 
-	@GetMapping(PATH_PARAM_SITE + PACKAGE + PATH_PARAM_PACKAGE + ITEMS)
+	@GetMapping(value = PATH_PARAM_SITE + PACKAGE + PATH_PARAM_PACKAGE + ITEMS, produces = APPLICATION_JSON_VALUE)
 	public PaginatedResultList<PublishItemWithMetadata> getPublishPackageItems(@PathVariable @ValidSiteId String site,
 										   @PathVariable @Positive long packageId,
 										   @RequestParam(name = REQUEST_PARAM_PATH, required = false) String path,
@@ -162,7 +162,7 @@ public class PublishController {
 		return result;
 	}
 
-	@GetMapping(PATH_PARAM_SITE + STATUS)
+	@GetMapping(value = PATH_PARAM_SITE + STATUS, produces = APPLICATION_JSON_VALUE)
 	public ResultOne<PublishStatus> getPublishingStatus(@PathVariable @ValidSiteId String site)
 			throws SiteNotFoundException, RepositoryException {
 		PublishStatus status = sitesService.getPublishingStatus(site);
@@ -195,7 +195,7 @@ public class PublishController {
 		return result;
 	}
 
-	@PostMapping(value = PATH_PARAM_SITE + CALCULATE, consumes = APPLICATION_JSON_VALUE)
+	@PostMapping(value = PATH_PARAM_SITE + CALCULATE, consumes = APPLICATION_JSON_VALUE, produces = APPLICATION_JSON_VALUE)
 	public ResultOne<CalculatedPublishPackageResult> calculatePublishPackage(@PathVariable @NotEmpty @ValidSiteId String site,
 										 @Validated @RequestBody CalculatePublishPackageRequest request)
 		throws ServiceLayerException, IOException {
@@ -208,7 +208,7 @@ public class PublishController {
 		return result;
 	}
 
-	@PostMapping(value = PATH_PARAM_SITE + PACKAGE + PATH_PARAM_PACKAGE + RECALCULATE, consumes = APPLICATION_JSON_VALUE)
+	@PostMapping(value = PATH_PARAM_SITE + PACKAGE + PATH_PARAM_PACKAGE + RECALCULATE, consumes = APPLICATION_JSON_VALUE, produces = APPLICATION_JSON_VALUE)
 	public ResultOne<CalculatedPublishPackageResult> recalculate(@PathVariable @NotEmpty @ValidSiteId String site,
 								     @PathVariable @Positive long packageId,
 								     @Valid @RequestBody RecalculatePublishPackageRequest request)
@@ -222,7 +222,7 @@ public class PublishController {
 		return result;
 	}
 
-	@PostMapping(value = PATH_PARAM_SITE + ENABLE_PUBLISHER, consumes = APPLICATION_JSON_VALUE)
+	@PostMapping(value = PATH_PARAM_SITE + ENABLE_PUBLISHER, consumes = APPLICATION_JSON_VALUE, produces = APPLICATION_JSON_VALUE)
 	public Result enablePublisher(@PathVariable @NotEmpty @ValidSiteId String site, @RequestBody EnablePublisherRequest request) {
 		sitesService.enablePublishing(site, request.isEnable());
 		Result result = new Result();
@@ -231,7 +231,7 @@ public class PublishController {
 	}
 
 	@ResponseStatus(HttpStatus.CREATED)
-	@PostMapping(value = PATH_PARAM_SITE + PACKAGE, consumes = APPLICATION_JSON_VALUE)
+	@PostMapping(value = PATH_PARAM_SITE + PACKAGE, consumes = APPLICATION_JSON_VALUE, produces = APPLICATION_JSON_VALUE)
 	public ResultOne<Long> publish(@PathVariable @NotEmpty @ValidSiteId String site,
 				       @Validated @RequestBody PublishPackageRequest request)
 		throws ServiceLayerException, UserNotFoundException, AuthenticationException {

--- a/studio/src/main/java/org/craftercms/studio/controller/rest/v2/PublishController.java
+++ b/studio/src/main/java/org/craftercms/studio/controller/rest/v2/PublishController.java
@@ -62,7 +62,7 @@ import static org.craftercms.studio.controller.rest.v2.RequestMappingConstants.*
 import static org.craftercms.studio.controller.rest.v2.ResultConstants.*;
 import static org.craftercms.studio.model.rest.ApiResponse.CREATED;
 import static org.craftercms.studio.model.rest.ApiResponse.OK;
-import static org.springframework.util.MimeTypeUtils.APPLICATION_JSON_VALUE;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 @Validated
 @RestController
@@ -126,7 +126,7 @@ public class PublishController {
 		return result;
 	}
 
-	@PostMapping(PATH_PARAM_SITE + PACKAGE + PATH_PARAM_PACKAGE)
+	@PostMapping(value = PATH_PARAM_SITE + PACKAGE + PATH_PARAM_PACKAGE, consumes = APPLICATION_JSON_VALUE)
 	public Result updatePublishPackage(@PathVariable @ValidSiteId String site,
 			@PathVariable @Positive long packageId, @Validated @RequestBody UpdatePackageRequest request)
 			throws InvalidPackageStateException, SiteNotFoundException, AuthenticationException {
@@ -195,7 +195,7 @@ public class PublishController {
 		return result;
 	}
 
-	@PostMapping(PATH_PARAM_SITE + CALCULATE)
+	@PostMapping(value = PATH_PARAM_SITE + CALCULATE, consumes = APPLICATION_JSON_VALUE)
 	public ResultOne<CalculatedPublishPackageResult> calculatePublishPackage(@PathVariable @NotEmpty @ValidSiteId String site,
 										 @Validated @RequestBody CalculatePublishPackageRequest request)
 		throws ServiceLayerException, IOException {
@@ -208,7 +208,7 @@ public class PublishController {
 		return result;
 	}
 
-	@PostMapping(PATH_PARAM_SITE + PACKAGE + PATH_PARAM_PACKAGE + RECALCULATE)
+	@PostMapping(value = PATH_PARAM_SITE + PACKAGE + PATH_PARAM_PACKAGE + RECALCULATE, consumes = APPLICATION_JSON_VALUE)
 	public ResultOne<CalculatedPublishPackageResult> recalculate(@PathVariable @NotEmpty @ValidSiteId String site,
 								     @PathVariable @Positive long packageId,
 								     @Valid @RequestBody RecalculatePublishPackageRequest request)
@@ -222,7 +222,7 @@ public class PublishController {
 		return result;
 	}
 
-	@PostMapping(PATH_PARAM_SITE + ENABLE_PUBLISHER)
+	@PostMapping(value = PATH_PARAM_SITE + ENABLE_PUBLISHER, consumes = APPLICATION_JSON_VALUE)
 	public Result enablePublisher(@PathVariable @NotEmpty @ValidSiteId String site, @RequestBody EnablePublisherRequest request) {
 		sitesService.enablePublishing(site, request.isEnable());
 		Result result = new Result();
@@ -231,7 +231,7 @@ public class PublishController {
 	}
 
 	@ResponseStatus(HttpStatus.CREATED)
-	@PostMapping(PATH_PARAM_SITE + PACKAGE)
+	@PostMapping(value = PATH_PARAM_SITE + PACKAGE, consumes = APPLICATION_JSON_VALUE)
 	public ResultOne<Long> publish(@PathVariable @NotEmpty @ValidSiteId String site,
 				       @Validated @RequestBody PublishPackageRequest request)
 		throws ServiceLayerException, UserNotFoundException, AuthenticationException {

--- a/studio/src/main/java/org/craftercms/studio/controller/rest/v2/RepositoryManagementController.java
+++ b/studio/src/main/java/org/craftercms/studio/controller/rest/v2/RepositoryManagementController.java
@@ -62,7 +62,7 @@ public class RepositoryManagementController {
 	}
 
 	@ResponseStatus(HttpStatus.CREATED)
-	@PostMapping(value = ADD_REMOTE, consumes = APPLICATION_JSON_VALUE)
+	@PostMapping(value = ADD_REMOTE, consumes = APPLICATION_JSON_VALUE, produces = APPLICATION_JSON_VALUE)
 	public Result addRemote(HttpServletResponse response, @Valid @RequestBody RemoteRepository remoteRepository)
 		throws ServiceLayerException, InvalidRemoteUrlException {
 		Result result = new Result();
@@ -82,7 +82,7 @@ public class RepositoryManagementController {
 		return result;
 	}
 
-	@PostMapping(value = PULL_FROM_REMOTE, consumes = APPLICATION_JSON_VALUE)
+	@PostMapping(value = PULL_FROM_REMOTE, consumes = APPLICATION_JSON_VALUE, produces = APPLICATION_JSON_VALUE)
 	public ResultOne<MergeResult> pullFromRemote(@Valid @RequestBody PullFromRemoteRequest pullFromRemoteRequest)
 		throws InvalidRemoteUrlException, ServiceLayerException,
 		InvalidRemoteRepositoryCredentialsException, RemoteRepositoryNotFoundException {
@@ -96,7 +96,7 @@ public class RepositoryManagementController {
 		return result;
 	}
 
-	@PostMapping(value = PUSH_TO_REMOTE, consumes = APPLICATION_JSON_VALUE)
+	@PostMapping(value = PUSH_TO_REMOTE, consumes = APPLICATION_JSON_VALUE, produces = APPLICATION_JSON_VALUE)
 	public Result pushToRemote(HttpServletResponse response, @Valid @RequestBody PushToRemoteRequest pushToRemoteRequest)
 		throws InvalidRemoteUrlException, ServiceLayerException,
 		InvalidRemoteRepositoryCredentialsException, RemoteRepositoryNotFoundException {
@@ -114,7 +114,7 @@ public class RepositoryManagementController {
 		return result;
 	}
 
-	@PostMapping(value = REMOVE_REMOTE, consumes = APPLICATION_JSON_VALUE)
+	@PostMapping(value = REMOVE_REMOTE, consumes = APPLICATION_JSON_VALUE, produces = APPLICATION_JSON_VALUE)
 	public Result removeRemote(HttpServletResponse response, @Valid @RequestBody RemoveRemoteRequest removeRemoteRequest)
 		throws SiteNotFoundException, RemoteNotRemovableException {
 		boolean res = repositoryManagementService.removeRemote(removeRemoteRequest.getSiteId(),
@@ -130,7 +130,7 @@ public class RepositoryManagementController {
 		return result;
 	}
 
-	@GetMapping(STATUS)
+	@GetMapping(value = STATUS, produces = APPLICATION_JSON_VALUE)
 	public ResultOne<RepositoryStatus> getRepositoryStatus(@ValidSiteId @RequestParam(value = REQUEST_PARAM_SITEID) String siteId)
 		throws ServiceLayerException {
 		RepositoryStatus status = repositoryManagementService.getRepositoryStatus(siteId);
@@ -140,7 +140,7 @@ public class RepositoryManagementController {
 		return result;
 	}
 
-	@PostMapping(value = RESOLVE_CONFLICT, consumes = APPLICATION_JSON_VALUE)
+	@PostMapping(value = RESOLVE_CONFLICT, consumes = APPLICATION_JSON_VALUE, produces = APPLICATION_JSON_VALUE)
 	public ResultOne<RepositoryStatus> resolveConflict(@Valid @RequestBody ResolveConflictRequest resolveConflictRequest)
 		throws ServiceLayerException {
 		String path = resolveConflictRequest.getPath();
@@ -155,7 +155,7 @@ public class RepositoryManagementController {
 		return result;
 	}
 
-	@GetMapping(DIFF_CONFLICTED_FILE)
+	@GetMapping(value = DIFF_CONFLICTED_FILE, produces = APPLICATION_JSON_VALUE)
 	public ResultOne<DiffConflictedFile> getDiffForConflictedFile(@ValidSiteId @RequestParam(value = REQUEST_PARAM_SITEID) String siteId,
 								      @ValidExistingContentPath @RequestParam(value = REQUEST_PARAM_PATH) String path)
 		throws ServiceLayerException {
@@ -170,7 +170,7 @@ public class RepositoryManagementController {
 		return result;
 	}
 
-	@PostMapping(value = COMMIT_RESOLUTION, consumes = APPLICATION_JSON_VALUE)
+	@PostMapping(value = COMMIT_RESOLUTION, consumes = APPLICATION_JSON_VALUE, produces = APPLICATION_JSON_VALUE)
 	public ResultOne<RepositoryStatus> commitConflictResolution(@Valid @RequestBody CommitResolutionRequest commitResolutionRequest)
 		throws ServiceLayerException {
 		RepositoryStatus status = repositoryManagementService.commitResolution(commitResolutionRequest.getSiteId(),
@@ -181,7 +181,7 @@ public class RepositoryManagementController {
 		return result;
 	}
 
-	@PostMapping(value = CANCEL_FAILED_PULL, consumes = APPLICATION_JSON_VALUE)
+	@PostMapping(value = CANCEL_FAILED_PULL, consumes = APPLICATION_JSON_VALUE, produces = APPLICATION_JSON_VALUE)
 	public ResultOne<RepositoryStatus> cancelFailedPull(@Valid @RequestBody CancelFailedPullRequest cancelFailedPullRequest)
 		throws ServiceLayerException {
 		RepositoryStatus status = repositoryManagementService.cancelFailedPull(cancelFailedPullRequest.getSiteId());
@@ -191,7 +191,7 @@ public class RepositoryManagementController {
 		return result;
 	}
 
-	@PostMapping(value = UNLOCK, consumes = APPLICATION_JSON_VALUE)
+	@PostMapping(value = UNLOCK, consumes = APPLICATION_JSON_VALUE, produces = APPLICATION_JSON_VALUE)
 	public Result unlockRepository(@Valid @RequestBody UnlockRepositoryRequest unlockRepositoryRequest) throws ServiceLayerException {
 		repositoryManagementService.unlockRepository(unlockRepositoryRequest.getSiteId(), unlockRepositoryRequest.getRepositoryType());
 		Result result = new Result();
@@ -199,7 +199,7 @@ public class RepositoryManagementController {
 		return result;
 	}
 
-	@GetMapping(CORRUPTED)
+	@GetMapping(value = CORRUPTED, produces = APPLICATION_JSON_VALUE)
 	public ResultOne<Boolean> isRepositoryCorrupted(@ValidSiteId @RequestParam(required = false) String siteId,
 							@RequestParam GitRepositories repositoryType)
 		throws ServiceLayerException {
@@ -210,7 +210,7 @@ public class RepositoryManagementController {
 		return result;
 	}
 
-	@PostMapping(value = REPAIR, consumes = APPLICATION_JSON_VALUE)
+	@PostMapping(value = REPAIR, consumes = APPLICATION_JSON_VALUE, produces = APPLICATION_JSON_VALUE)
 	public Result repairCorruptedRepository(@Valid @RequestBody RepairRepositoryRequest request)
 		throws ServiceLayerException {
 		repositoryManagementService.repairCorrupted(request.getSiteId(), request.getRepositoryType());

--- a/studio/src/main/java/org/craftercms/studio/controller/rest/v2/RepositoryManagementController.java
+++ b/studio/src/main/java/org/craftercms/studio/controller/rest/v2/RepositoryManagementController.java
@@ -62,7 +62,7 @@ public class RepositoryManagementController {
 	}
 
 	@ResponseStatus(HttpStatus.CREATED)
-	@PostMapping(ADD_REMOTE)
+	@PostMapping(value = ADD_REMOTE, consumes = APPLICATION_JSON_VALUE)
 	public Result addRemote(HttpServletResponse response, @Valid @RequestBody RemoteRepository remoteRepository)
 		throws ServiceLayerException, InvalidRemoteUrlException {
 		Result result = new Result();
@@ -82,7 +82,7 @@ public class RepositoryManagementController {
 		return result;
 	}
 
-	@PostMapping(PULL_FROM_REMOTE)
+	@PostMapping(value = PULL_FROM_REMOTE, consumes = APPLICATION_JSON_VALUE)
 	public ResultOne<MergeResult> pullFromRemote(@Valid @RequestBody PullFromRemoteRequest pullFromRemoteRequest)
 		throws InvalidRemoteUrlException, ServiceLayerException,
 		InvalidRemoteRepositoryCredentialsException, RemoteRepositoryNotFoundException {
@@ -96,7 +96,7 @@ public class RepositoryManagementController {
 		return result;
 	}
 
-	@PostMapping(PUSH_TO_REMOTE)
+	@PostMapping(value = PUSH_TO_REMOTE, consumes = APPLICATION_JSON_VALUE)
 	public Result pushToRemote(HttpServletResponse response, @Valid @RequestBody PushToRemoteRequest pushToRemoteRequest)
 		throws InvalidRemoteUrlException, ServiceLayerException,
 		InvalidRemoteRepositoryCredentialsException, RemoteRepositoryNotFoundException {
@@ -114,7 +114,7 @@ public class RepositoryManagementController {
 		return result;
 	}
 
-	@PostMapping(REMOVE_REMOTE)
+	@PostMapping(value = REMOVE_REMOTE, consumes = APPLICATION_JSON_VALUE)
 	public Result removeRemote(HttpServletResponse response, @Valid @RequestBody RemoveRemoteRequest removeRemoteRequest)
 		throws SiteNotFoundException, RemoteNotRemovableException {
 		boolean res = repositoryManagementService.removeRemote(removeRemoteRequest.getSiteId(),
@@ -140,7 +140,7 @@ public class RepositoryManagementController {
 		return result;
 	}
 
-	@PostMapping(RESOLVE_CONFLICT)
+	@PostMapping(value = RESOLVE_CONFLICT, consumes = APPLICATION_JSON_VALUE)
 	public ResultOne<RepositoryStatus> resolveConflict(@Valid @RequestBody ResolveConflictRequest resolveConflictRequest)
 		throws ServiceLayerException {
 		String path = resolveConflictRequest.getPath();
@@ -170,7 +170,7 @@ public class RepositoryManagementController {
 		return result;
 	}
 
-	@PostMapping(COMMIT_RESOLUTION)
+	@PostMapping(value = COMMIT_RESOLUTION, consumes = APPLICATION_JSON_VALUE)
 	public ResultOne<RepositoryStatus> commitConflictResolution(@Valid @RequestBody CommitResolutionRequest commitResolutionRequest)
 		throws ServiceLayerException {
 		RepositoryStatus status = repositoryManagementService.commitResolution(commitResolutionRequest.getSiteId(),
@@ -181,7 +181,7 @@ public class RepositoryManagementController {
 		return result;
 	}
 
-	@PostMapping(CANCEL_FAILED_PULL)
+	@PostMapping(value = CANCEL_FAILED_PULL, consumes = APPLICATION_JSON_VALUE)
 	public ResultOne<RepositoryStatus> cancelFailedPull(@Valid @RequestBody CancelFailedPullRequest cancelFailedPullRequest)
 		throws ServiceLayerException {
 		RepositoryStatus status = repositoryManagementService.cancelFailedPull(cancelFailedPullRequest.getSiteId());
@@ -191,7 +191,7 @@ public class RepositoryManagementController {
 		return result;
 	}
 
-	@PostMapping(UNLOCK)
+	@PostMapping(value = UNLOCK, consumes = APPLICATION_JSON_VALUE)
 	public Result unlockRepository(@Valid @RequestBody UnlockRepositoryRequest unlockRepositoryRequest) throws ServiceLayerException {
 		repositoryManagementService.unlockRepository(unlockRepositoryRequest.getSiteId(), unlockRepositoryRequest.getRepositoryType());
 		Result result = new Result();
@@ -210,7 +210,7 @@ public class RepositoryManagementController {
 		return result;
 	}
 
-	@PostMapping(REPAIR)
+	@PostMapping(value = REPAIR, consumes = APPLICATION_JSON_VALUE)
 	public Result repairCorruptedRepository(@Valid @RequestBody RepairRepositoryRequest request)
 		throws ServiceLayerException {
 		repositoryManagementService.repairCorrupted(request.getSiteId(), request.getRepositoryType());

--- a/studio/src/main/java/org/craftercms/studio/controller/rest/v2/SearchController.java
+++ b/studio/src/main/java/org/craftercms/studio/controller/rest/v2/SearchController.java
@@ -32,6 +32,7 @@ import jakarta.validation.Valid;
 import java.beans.ConstructorProperties;
 
 import static org.craftercms.studio.controller.rest.v2.ResultConstants.RESULT_KEY_RESULT;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 /**
  * Controller to access the search service
@@ -53,7 +54,7 @@ public class SearchController {
 		this.searchService = searchService;
 	}
 
-	@PostMapping(value = "/search")
+	@PostMapping(value = "/search", consumes = APPLICATION_JSON_VALUE)
 	public ResultOne<SearchResult> search(@ValidSiteId @RequestParam String siteId, @Valid @RequestBody SearchParams params)
 		throws AuthenticationException, ServiceLayerException {
 		SearchResult searchResult = searchService.search(siteId, params);

--- a/studio/src/main/java/org/craftercms/studio/controller/rest/v2/SearchController.java
+++ b/studio/src/main/java/org/craftercms/studio/controller/rest/v2/SearchController.java
@@ -54,7 +54,7 @@ public class SearchController {
 		this.searchService = searchService;
 	}
 
-	@PostMapping(value = "/search", consumes = APPLICATION_JSON_VALUE)
+	@PostMapping(value = "/search", consumes = APPLICATION_JSON_VALUE, produces = APPLICATION_JSON_VALUE)
 	public ResultOne<SearchResult> search(@ValidSiteId @RequestParam String siteId, @Valid @RequestBody SearchParams params)
 		throws AuthenticationException, ServiceLayerException {
 		SearchResult searchResult = searchService.search(siteId, params);

--- a/studio/src/main/java/org/craftercms/studio/controller/rest/v2/SecurityController.java
+++ b/studio/src/main/java/org/craftercms/studio/controller/rest/v2/SecurityController.java
@@ -33,6 +33,7 @@ import jakarta.validation.Valid;
 import java.beans.ConstructorProperties;
 
 import static org.craftercms.studio.controller.rest.v2.ResultConstants.*;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 /**
  * Rest controller that provides access to security operations
@@ -54,7 +55,7 @@ public class SecurityController {
 		this.accessTokenService = accessTokenService;
 	}
 
-	@PostMapping("/encrypt")
+	@PostMapping(value = "/encrypt", consumes = APPLICATION_JSON_VALUE)
 	public ResultOne<String> encryptText(@Valid @RequestBody EncryptRequest request) throws ServiceLayerException {
 		String encrypted = encryptionService.encrypt(request.getSiteId(), request.getText());
 
@@ -73,7 +74,7 @@ public class SecurityController {
 		return result;
 	}
 
-	@PostMapping("/tokens")
+	@PostMapping(value = "/tokens", consumes = APPLICATION_JSON_VALUE)
 	@ResponseStatus(HttpStatus.CREATED)
 	public ResultOne<PersistentAccessToken> createAccessToken(@Valid @RequestBody CreateAccessTokenRequest request) throws ServiceLayerException {
 		var result = new ResultOne<PersistentAccessToken>();
@@ -82,7 +83,7 @@ public class SecurityController {
 		return result;
 	}
 
-	@PostMapping("/tokens/{tokenId}")
+	@PostMapping(value = "/tokens/{tokenId}", consumes = APPLICATION_JSON_VALUE)
 	public ResultOne<PersistentAccessToken> updateAccessToken(@PathVariable long tokenId, @RequestBody UpdateAccessTokenRequest request) {
 		var result = new ResultOne<PersistentAccessToken>();
 		result.setEntity(RESULT_KEY_TOKEN, accessTokenService.updateAccessToken(tokenId, request.isEnabled()));

--- a/studio/src/main/java/org/craftercms/studio/controller/rest/v2/SecurityController.java
+++ b/studio/src/main/java/org/craftercms/studio/controller/rest/v2/SecurityController.java
@@ -55,7 +55,7 @@ public class SecurityController {
 		this.accessTokenService = accessTokenService;
 	}
 
-	@PostMapping(value = "/encrypt", consumes = APPLICATION_JSON_VALUE)
+	@PostMapping(value = "/encrypt", consumes = APPLICATION_JSON_VALUE, produces = APPLICATION_JSON_VALUE)
 	public ResultOne<String> encryptText(@Valid @RequestBody EncryptRequest request) throws ServiceLayerException {
 		String encrypted = encryptionService.encrypt(request.getSiteId(), request.getText());
 
@@ -66,7 +66,7 @@ public class SecurityController {
 		return result;
 	}
 
-	@GetMapping("/tokens")
+	@GetMapping(value = "/tokens", produces = APPLICATION_JSON_VALUE)
 	public ResultList<PersistentAccessToken> getAccessTokens() {
 		var result = new ResultList<PersistentAccessToken>();
 		result.setEntities(RESULT_KEY_TOKENS, accessTokenService.getAccessTokens());
@@ -74,7 +74,7 @@ public class SecurityController {
 		return result;
 	}
 
-	@PostMapping(value = "/tokens", consumes = APPLICATION_JSON_VALUE)
+	@PostMapping(value = "/tokens", consumes = APPLICATION_JSON_VALUE, produces = APPLICATION_JSON_VALUE)
 	@ResponseStatus(HttpStatus.CREATED)
 	public ResultOne<PersistentAccessToken> createAccessToken(@Valid @RequestBody CreateAccessTokenRequest request) throws ServiceLayerException {
 		var result = new ResultOne<PersistentAccessToken>();
@@ -83,7 +83,7 @@ public class SecurityController {
 		return result;
 	}
 
-	@PostMapping(value = "/tokens/{tokenId}", consumes = APPLICATION_JSON_VALUE)
+	@PostMapping(value = "/tokens/{tokenId}", consumes = APPLICATION_JSON_VALUE, produces = APPLICATION_JSON_VALUE)
 	public ResultOne<PersistentAccessToken> updateAccessToken(@PathVariable long tokenId, @RequestBody UpdateAccessTokenRequest request) {
 		var result = new ResultOne<PersistentAccessToken>();
 		result.setEntity(RESULT_KEY_TOKEN, accessTokenService.updateAccessToken(tokenId, request.isEnabled()));
@@ -91,7 +91,7 @@ public class SecurityController {
 		return result;
 	}
 
-	@DeleteMapping("/tokens/{tokenId}")
+	@DeleteMapping(value = "/tokens/{tokenId}", produces = APPLICATION_JSON_VALUE)
 	public Result deleteAccessToken(@PathVariable long tokenId) {
 		accessTokenService.deleteAccessToken(tokenId);
 		var result = new Result();
@@ -99,7 +99,7 @@ public class SecurityController {
 		return result;
 	}
 
-	@PostMapping("/preview/switch")
+	@PostMapping(value = "/preview/switch", produces = APPLICATION_JSON_VALUE)
 	public Result switchPreviewSite(Authentication authentication, HttpServletRequest request, HttpServletResponse response)
 		throws ServiceLayerException {
 		accessTokenService.refreshPreviewCookie(authentication, request, response, false);

--- a/studio/src/main/java/org/craftercms/studio/controller/rest/v2/SitesController.java
+++ b/studio/src/main/java/org/craftercms/studio/controller/rest/v2/SitesController.java
@@ -58,6 +58,7 @@ import java.util.List;
 import static org.craftercms.studio.controller.rest.v2.RequestMappingConstants.*;
 import static org.craftercms.studio.controller.rest.v2.ResultConstants.*;
 import static org.craftercms.studio.model.rest.ApiResponse.OK;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 @Validated
 @RestController
@@ -87,7 +88,7 @@ public class SitesController {
 		return result;
 	}
 
-	@PostMapping("/create_site_from_marketplace")
+	@PostMapping(value = "/create_site_from_marketplace", consumes = APPLICATION_JSON_VALUE)
 	@ResponseStatus(code = HttpStatus.CREATED)
 	public Result createSite(@Valid @RequestBody CreateSiteFromMarketplaceRequest request)
 			throws RemoteRepositoryNotFoundException, InvalidRemoteRepositoryException, ServiceLayerException,
@@ -100,7 +101,7 @@ public class SitesController {
 		return result;
 	}
 
-	@PostMapping
+	@PostMapping(consumes = APPLICATION_JSON_VALUE)
 	@ResponseStatus(code = HttpStatus.CREATED)
 	public Result createSite(@Valid @RequestBody CreateSiteRequest request)
 			throws ServiceLayerException, InvalidRemoteRepositoryCredentialsException, RemoteRepositoryNotFoundException, InvalidRemoteRepositoryException {
@@ -110,7 +111,7 @@ public class SitesController {
 		return result;
 	}
 
-	@PostMapping("/{siteId}")
+	@PostMapping(value = "/{siteId}", consumes = APPLICATION_JSON_VALUE)
 	public Result updateSite(@ValidSiteId @PathVariable String siteId,
 							 @Valid @RequestBody UpdateSiteRequest request)
 			throws SiteNotFoundException, SiteAlreadyExistsException, InvalidParametersException {
@@ -140,7 +141,7 @@ public class SitesController {
 		return result;
 	}
 
-	@PostMapping("/{siteId}/policy/validate")
+	@PostMapping(value = "/{siteId}/policy/validate", consumes = APPLICATION_JSON_VALUE)
 	public ResultList<ValidationResult> validatePolicy(@ValidSiteId @PathVariable String siteId,
 													   @Valid @RequestBody ValidatePolicyRequest request)
 			throws ConfigurationException, IOException, ContentNotFoundException {
@@ -152,7 +153,7 @@ public class SitesController {
 		return result;
 	}
 
-	@PostMapping("/{siteId}/duplicate")
+	@PostMapping(value = "/{siteId}/duplicate", consumes = APPLICATION_JSON_VALUE)
 	@ResponseStatus(code = HttpStatus.CREATED)
 	public Result duplicateSite(@ValidSiteId @PathVariable("siteId") String sourceSiteId, @Valid @RequestBody DuplicateSiteRequest request)
 			throws ServiceLayerException {

--- a/studio/src/main/java/org/craftercms/studio/controller/rest/v2/SitesController.java
+++ b/studio/src/main/java/org/craftercms/studio/controller/rest/v2/SitesController.java
@@ -79,7 +79,7 @@ public class SitesController {
 		this.policyService = policyService;
 	}
 
-	@GetMapping("/available_blueprints")
+	@GetMapping(value = "/available_blueprints", produces = APPLICATION_JSON_VALUE)
 	public ResultList<PluginDescriptor> getAvailableBlueprints() throws ServiceLayerException {
 		List<PluginDescriptor> blueprintDescriptors = sitesService.getAvailableBlueprints();
 		ResultList<PluginDescriptor> result = new ResultList<>();
@@ -88,7 +88,7 @@ public class SitesController {
 		return result;
 	}
 
-	@PostMapping(value = "/create_site_from_marketplace", consumes = APPLICATION_JSON_VALUE)
+	@PostMapping(value = "/create_site_from_marketplace", consumes = APPLICATION_JSON_VALUE, produces = APPLICATION_JSON_VALUE)
 	@ResponseStatus(code = HttpStatus.CREATED)
 	public Result createSite(@Valid @RequestBody CreateSiteFromMarketplaceRequest request)
 			throws RemoteRepositoryNotFoundException, InvalidRemoteRepositoryException, ServiceLayerException,
@@ -101,7 +101,7 @@ public class SitesController {
 		return result;
 	}
 
-	@PostMapping(consumes = APPLICATION_JSON_VALUE)
+	@PostMapping(consumes = APPLICATION_JSON_VALUE, produces = APPLICATION_JSON_VALUE)
 	@ResponseStatus(code = HttpStatus.CREATED)
 	public Result createSite(@Valid @RequestBody CreateSiteRequest request)
 			throws ServiceLayerException, InvalidRemoteRepositoryCredentialsException, RemoteRepositoryNotFoundException, InvalidRemoteRepositoryException {
@@ -111,7 +111,7 @@ public class SitesController {
 		return result;
 	}
 
-	@PostMapping(value = "/{siteId}", consumes = APPLICATION_JSON_VALUE)
+	@PostMapping(value = "/{siteId}", consumes = APPLICATION_JSON_VALUE, produces = APPLICATION_JSON_VALUE)
 	public Result updateSite(@ValidSiteId @PathVariable String siteId,
 							 @Valid @RequestBody UpdateSiteRequest request)
 			throws SiteNotFoundException, SiteAlreadyExistsException, InvalidParametersException {
@@ -123,7 +123,7 @@ public class SitesController {
 		return result;
 	}
 
-	@PostMapping("/{siteId}/unlock")
+	@PostMapping(value = "/{siteId}/unlock", produces = APPLICATION_JSON_VALUE)
 	public Result unlockSite(@ValidSiteId @PathVariable String siteId) throws SiteNotFoundException, InvalidSiteStateException {
 		sitesService.unlockSite(siteId);
 		var result = new Result();
@@ -131,7 +131,7 @@ public class SitesController {
 		return result;
 	}
 
-	@DeleteMapping("/{siteId}")
+	@DeleteMapping(value = "/{siteId}", produces = APPLICATION_JSON_VALUE)
 	public Result deleteSite(@ValidSiteId @PathVariable String siteId)
 			throws ServiceLayerException {
 		sitesService.deleteSite(siteId);
@@ -141,7 +141,7 @@ public class SitesController {
 		return result;
 	}
 
-	@PostMapping(value = "/{siteId}/policy/validate", consumes = APPLICATION_JSON_VALUE)
+	@PostMapping(value = "/{siteId}/policy/validate", consumes = APPLICATION_JSON_VALUE, produces = APPLICATION_JSON_VALUE)
 	public ResultList<ValidationResult> validatePolicy(@ValidSiteId @PathVariable String siteId,
 													   @Valid @RequestBody ValidatePolicyRequest request)
 			throws ConfigurationException, IOException, ContentNotFoundException {
@@ -153,7 +153,7 @@ public class SitesController {
 		return result;
 	}
 
-	@PostMapping(value = "/{siteId}/duplicate", consumes = APPLICATION_JSON_VALUE)
+	@PostMapping(value = "/{siteId}/duplicate", consumes = APPLICATION_JSON_VALUE, produces = APPLICATION_JSON_VALUE)
 	@ResponseStatus(code = HttpStatus.CREATED)
 	public Result duplicateSite(@ValidSiteId @PathVariable("siteId") String sourceSiteId, @Valid @RequestBody DuplicateSiteRequest request)
 			throws ServiceLayerException {
@@ -166,7 +166,7 @@ public class SitesController {
 		return result;
 	}
 
-	@GetMapping(SITE_ID + EXISTS)
+	@GetMapping(value = SITE_ID + EXISTS, produces = APPLICATION_JSON_VALUE)
 	public ResultOne<Boolean> siteExists(@ValidSiteId @PathVariable String siteId) {
 		boolean exists = sitesService.exists(siteId);
 		var result = new ResultOne<Boolean>();
@@ -175,7 +175,7 @@ public class SitesController {
 		return result;
 	}
 
-	@GetMapping(SITE_ID)
+	@GetMapping(value = SITE_ID, produces = APPLICATION_JSON_VALUE)
 	public ResultOne<SiteDetails> getSite(@ValidSiteId @PathVariable String siteId) throws ServiceLayerException {
 		SiteDetails site = sitesService.getSiteDetails(siteId);
 		var result = new ResultOne<SiteDetails>();
@@ -184,7 +184,7 @@ public class SitesController {
 		return result;
 	}
 
-	@GetMapping(SITE_ID + MONITOR)
+	@GetMapping(value = SITE_ID + MONITOR, produces = APPLICATION_JSON_VALUE)
 	public ResultList<SiteMonitor> monitorSite(@ValidSiteId @PathVariable String siteId) throws ServiceLayerException {
 		Collection<SiteMonitor> siteMonitors = sitesService.monitorSite(siteId);
 		ResultList<SiteMonitor> result = new ResultList<>();
@@ -193,7 +193,7 @@ public class SitesController {
 		return result;
 	}
 
-	@GetMapping(MONITOR)
+	@GetMapping(value = MONITOR, produces = APPLICATION_JSON_VALUE)
 	public ResultOne<AllSitesMonitors> monitorAllSites() {
 		AllSitesMonitors monitorResult = sitesService.monitorAllSites();
 		ResultOne<AllSitesMonitors> result = new ResultOne<>();

--- a/studio/src/main/java/org/craftercms/studio/controller/rest/v2/SystemController.java
+++ b/studio/src/main/java/org/craftercms/studio/controller/rest/v2/SystemController.java
@@ -60,7 +60,7 @@ public class SystemController {
 		this.configurationService = configurationService;
 	}
 
-	@GetMapping(PROPERTIES)
+	@GetMapping(value = PROPERTIES, produces = APPLICATION_JSON_VALUE)
 	public ResultOne<Map<String, String>> getSystemProperties(@RequestParam @NotEmpty
 															  List<@Size(max = 50) @ValidateNoTagsParam @ValidateStringParam(whitelistedPatterns = PROPERTY_NAME_ALLOWED_PATTERN) String> properties) {
 		ResultOne<Map<String, String>> result = new ResultOne<>();
@@ -69,7 +69,7 @@ public class SystemController {
 		return result;
 	}
 
-	@PostMapping(value = PROPERTIES, consumes = APPLICATION_JSON_VALUE)
+	@PostMapping(value = PROPERTIES, consumes = APPLICATION_JSON_VALUE, produces = APPLICATION_JSON_VALUE)
 	public Result setSystemProperties(@Valid @RequestBody UpdateSystemPropertiesRequest request) {
 		systemPropertiesService.setSystemProperties(request.getProperties());
 		Result result = new Result();
@@ -77,7 +77,7 @@ public class SystemController {
 		return result;
 	}
 
-	@GetMapping(AVAILABLE_LANGUAGES)
+	@GetMapping(value = AVAILABLE_LANGUAGES, produces = APPLICATION_JSON_VALUE)
 	public ResultList<Language> getAvailableLanguages() throws ServiceLayerException {
 		var result = new ResultList<Language>();
 		result.setEntities(RESULT_KEY_LANGUAGES, configurationService.getAvailableLanguages());

--- a/studio/src/main/java/org/craftercms/studio/controller/rest/v2/SystemController.java
+++ b/studio/src/main/java/org/craftercms/studio/controller/rest/v2/SystemController.java
@@ -40,6 +40,7 @@ import static org.craftercms.studio.api.v2.service.system.SystemPropertiesServic
 import static org.craftercms.studio.controller.rest.v2.RequestMappingConstants.*;
 import static org.craftercms.studio.controller.rest.v2.ResultConstants.RESULT_KEY_LANGUAGES;
 import static org.craftercms.studio.model.rest.ApiResponse.OK;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 /**
  * Provides access to system properties
@@ -68,7 +69,7 @@ public class SystemController {
 		return result;
 	}
 
-	@PostMapping(PROPERTIES)
+	@PostMapping(value = PROPERTIES, consumes = APPLICATION_JSON_VALUE)
 	public Result setSystemProperties(@Valid @RequestBody UpdateSystemPropertiesRequest request) {
 		systemPropertiesService.setSystemProperties(request.getProperties());
 		Result result = new Result();

--- a/studio/src/main/java/org/craftercms/studio/controller/rest/v2/UiController.java
+++ b/studio/src/main/java/org/craftercms/studio/controller/rest/v2/UiController.java
@@ -32,6 +32,7 @@ import java.beans.ConstructorProperties;
 
 import static org.craftercms.studio.controller.rest.v2.ResultConstants.RESULT_KEY_ENVIRONMENT;
 import static org.craftercms.studio.controller.rest.v2.ResultConstants.RESULT_KEY_MENU_ITEMS;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 /**
  * Controller that provides the UI elements the current user has access to.
@@ -49,7 +50,7 @@ public class UiController {
 		this.uiService = uiService;
 	}
 
-	@GetMapping("/views/global_menu")
+	@GetMapping(value = "/views/global_menu", produces = APPLICATION_JSON_VALUE)
 	public ResultList<MenuItem> getGlobalMenu() throws AuthenticationException, ServiceLayerException, UserNotFoundException {
 		ResultList<MenuItem> result = new ResultList<>();
 		result.setResponse(ApiResponse.OK);
@@ -57,7 +58,7 @@ public class UiController {
 		return result;
 	}
 
-	@GetMapping("/system/active_environment")
+	@GetMapping(value = "/system/active_environment", produces = APPLICATION_JSON_VALUE)
 	public ResultOne<String> getActiveEnvironment() throws AuthenticationException {
 		ResultOne<String> result = new ResultOne<>();
 		result.setResponse(ApiResponse.OK);

--- a/studio/src/main/java/org/craftercms/studio/controller/rest/v2/UsersController.java
+++ b/studio/src/main/java/org/craftercms/studio/controller/rest/v2/UsersController.java
@@ -96,7 +96,7 @@ public class UsersController {
 	 * @param sort   Sort order
 	 * @return Response containing list of users
 	 */
-	@GetMapping
+	@GetMapping(produces = APPLICATION_JSON_VALUE)
 	public PaginatedResultList<UserResponse> getAllUsers(
 		@ValidSiteId @RequestParam(value = REQUEST_PARAM_SITE_ID, required = false) String siteId,
 		@EsapiValidatedParam(type = SEARCH_KEYWORDS) @RequestParam(value = REQUEST_PARAM_KEYWORD, required = false) String keyword,
@@ -132,7 +132,7 @@ public class UsersController {
 	 * @return Response object
 	 */
 	@ResponseStatus(HttpStatus.CREATED)
-	@PostMapping(consumes = APPLICATION_JSON_VALUE)
+	@PostMapping(consumes = APPLICATION_JSON_VALUE, produces = APPLICATION_JSON_VALUE)
 	public ResultOne<UserResponse> createUser(@Valid @RequestBody CreateUserRequest user)
 		throws UserAlreadyExistsException, ServiceLayerException, AuthenticationException {
 		UserResponse newUser = new UserResponse(userService.createUser(buildUser(user)));
@@ -172,7 +172,7 @@ public class UsersController {
 	 * @param user User to update
 	 * @return Response object
 	 */
-	@PatchMapping(consumes = APPLICATION_JSON_VALUE)
+	@PatchMapping(consumes = APPLICATION_JSON_VALUE, produces = APPLICATION_JSON_VALUE)
 	public ResultOne<UserResponse> updateUser(@Valid @RequestBody UpdateUserRequest user)
 		throws ServiceLayerException, UserNotFoundException, AuthenticationException, UserExternallyManagedException {
 		User userRequest = buildUser(user);
@@ -215,7 +215,7 @@ public class UsersController {
 	 * @param enableUsers Enable users request body (json representation)
 	 * @return Response object
 	 */
-	@PatchMapping(value = ENABLE, consumes = APPLICATION_JSON_VALUE)
+	@PatchMapping(value = ENABLE, consumes = APPLICATION_JSON_VALUE, produces = APPLICATION_JSON_VALUE)
 	public ResultList<UserResponse> enableUsers(@Valid @RequestBody EnableUsers enableUsers)
 		throws ServiceLayerException, UserNotFoundException, UserExternallyManagedException {
 		ValidationUtils.validateEnableUsers(enableUsers);
@@ -234,7 +234,7 @@ public class UsersController {
 	 * @param enableUsers Disable users request body (json representation)
 	 * @return Response object
 	 */
-	@PatchMapping(value = DISABLE, consumes = APPLICATION_JSON_VALUE)
+	@PatchMapping(value = DISABLE, consumes = APPLICATION_JSON_VALUE, produces = APPLICATION_JSON_VALUE)
 	public ResultList<UserResponse> disableUsers(@Valid @RequestBody EnableUsers enableUsers)
 		throws ServiceLayerException, UserNotFoundException, UserExternallyManagedException {
 		ValidationUtils.validateEnableUsers(enableUsers);
@@ -254,7 +254,7 @@ public class UsersController {
 	 * @param userId User identifier
 	 * @return Response containing list of sites
 	 */
-	@GetMapping(PATH_PARAM_ID + SITES)
+	@GetMapping(value = PATH_PARAM_ID + SITES, produces = APPLICATION_JSON_VALUE)
 	public PaginatedResultList<Site> getUserSites(
 		@NotNull @PathVariable(REQUEST_PARAM_ID) String userId,
 		@PositiveOrZero @RequestParam(value = REQUEST_PARAM_OFFSET, required = false, defaultValue = "0") int offset,
@@ -288,7 +288,7 @@ public class UsersController {
 	 * @param site   The site ID
 	 * @return Response containing list of roles
 	 */
-	@GetMapping(PATH_PARAM_ID + SITES + PATH_PARAM_SITE + ROLES)
+	@GetMapping(value = PATH_PARAM_ID + SITES + PATH_PARAM_SITE + ROLES, produces = APPLICATION_JSON_VALUE)
 	public ResultList<String> getUserSiteRoles(@NotNull @PathVariable(REQUEST_PARAM_ID) String userId,
 						   @NotNull @ValidSiteId @PathVariable(REQUEST_PARAM_SITE) String site)
 		throws ServiceLayerException, UserNotFoundException, ValidationException {
@@ -317,7 +317,7 @@ public class UsersController {
 	 *
 	 * @return Response containing current authenticated user
 	 */
-	@GetMapping(ME)
+	@GetMapping(value = ME, produces = APPLICATION_JSON_VALUE)
 	public ResultOne<AuthenticatedUser> getCurrentUser() throws AuthenticationException, ServiceLayerException {
 		AuthenticatedUser user = SecurityUtils.getCurrentUser();
 
@@ -333,7 +333,7 @@ public class UsersController {
 	 *
 	 * @return Response containing current authenticated user sites
 	 */
-	@GetMapping(ME + SITES)
+	@GetMapping(value = ME + SITES, produces = APPLICATION_JSON_VALUE)
 	public PaginatedResultList<Site> getCurrentUserSites(
 		@PositiveOrZero @RequestParam(value = REQUEST_PARAM_OFFSET, required = false, defaultValue = "0") int offset,
 		@PositiveOrZero @RequestParam(value = REQUEST_PARAM_LIMIT, required = false, defaultValue = "10") int limit)
@@ -356,7 +356,7 @@ public class UsersController {
 	 *
 	 * @return Response containing current authenticated user roles
 	 */
-	@GetMapping(ME + SITES + PATH_PARAM_SITE + ROLES)
+	@GetMapping(value = ME + SITES + PATH_PARAM_SITE + ROLES, produces = APPLICATION_JSON_VALUE)
 	public ResultList<String> getCurrentUserSiteRoles(@NotBlank @ValidSiteId @PathVariable(REQUEST_PARAM_SITE) String site)
 		throws AuthenticationException, ServiceLayerException, UserNotFoundException {
 		List<String> roles = userService.getCurrentUserSiteRoles(site);
@@ -368,7 +368,7 @@ public class UsersController {
 		return result;
 	}
 
-	@GetMapping(FORGOT_PASSWORD)
+	@GetMapping(value = FORGOT_PASSWORD, produces = APPLICATION_JSON_VALUE)
 	public ResultOne<String> forgotPassword(@NotBlank @RequestParam(value = REQUEST_PARAM_USERNAME) String username) {
 		int delay = studioConfiguration.getProperty(SECURITY_SET_PASSWORD_DELAY, Integer.class);
 		try {
@@ -388,7 +388,7 @@ public class UsersController {
 		return result;
 	}
 
-	@PostMapping(value = ME + CHANGE_PASSWORD, consumes = APPLICATION_JSON_VALUE)
+	@PostMapping(value = ME + CHANGE_PASSWORD, consumes = APPLICATION_JSON_VALUE, produces = APPLICATION_JSON_VALUE)
 	public ResultOne<UserResponse> changePassword(@Valid @RequestBody ChangePasswordRequest changePasswordRequest)
 		throws PasswordDoesNotMatchException, ServiceLayerException, UserExternallyManagedException,
 		AuthenticationException, UserNotFoundException {
@@ -407,7 +407,7 @@ public class UsersController {
 		return result;
 	}
 
-	@PostMapping(value = SET_PASSWORD, consumes = APPLICATION_JSON_VALUE)
+	@PostMapping(value = SET_PASSWORD, consumes = APPLICATION_JSON_VALUE, produces = APPLICATION_JSON_VALUE)
 	public ResultOne<UserResponse> setPassword(@Valid @RequestBody SetPasswordRequest setPasswordRequest)
 		throws UserNotFoundException, UserExternallyManagedException, ServiceLayerException {
 		int delay = studioConfiguration.getProperty(SECURITY_SET_PASSWORD_DELAY, Integer.class);
@@ -424,7 +424,7 @@ public class UsersController {
 		return result;
 	}
 
-	@PostMapping(value = PATH_PARAM_ID + RESET_PASSWORD, consumes = APPLICATION_JSON_VALUE)
+	@PostMapping(value = PATH_PARAM_ID + RESET_PASSWORD, consumes = APPLICATION_JSON_VALUE, produces = APPLICATION_JSON_VALUE)
 	public Result resetPassword(@NotBlank @EsapiValidatedParam(type = USERNAME) @PathVariable(REQUEST_PARAM_ID) String userId,
 				    @Valid @RequestBody ResetPasswordRequest resetPasswordRequest)
 		throws UserNotFoundException, UserExternallyManagedException, ServiceLayerException {

--- a/studio/src/main/java/org/craftercms/studio/controller/rest/v2/UsersController.java
+++ b/studio/src/main/java/org/craftercms/studio/controller/rest/v2/UsersController.java
@@ -388,7 +388,7 @@ public class UsersController {
 		return result;
 	}
 
-	@PostMapping(ME + CHANGE_PASSWORD)
+	@PostMapping(value = ME + CHANGE_PASSWORD, consumes = APPLICATION_JSON_VALUE)
 	public ResultOne<UserResponse> changePassword(@Valid @RequestBody ChangePasswordRequest changePasswordRequest)
 		throws PasswordDoesNotMatchException, ServiceLayerException, UserExternallyManagedException,
 		AuthenticationException, UserNotFoundException {
@@ -407,7 +407,7 @@ public class UsersController {
 		return result;
 	}
 
-	@PostMapping(SET_PASSWORD)
+	@PostMapping(value = SET_PASSWORD, consumes = APPLICATION_JSON_VALUE)
 	public ResultOne<UserResponse> setPassword(@Valid @RequestBody SetPasswordRequest setPasswordRequest)
 		throws UserNotFoundException, UserExternallyManagedException, ServiceLayerException {
 		int delay = studioConfiguration.getProperty(SECURITY_SET_PASSWORD_DELAY, Integer.class);
@@ -424,7 +424,7 @@ public class UsersController {
 		return result;
 	}
 
-	@PostMapping(PATH_PARAM_ID + RESET_PASSWORD)
+	@PostMapping(value = PATH_PARAM_ID + RESET_PASSWORD, consumes = APPLICATION_JSON_VALUE)
 	public Result resetPassword(@NotBlank @EsapiValidatedParam(type = USERNAME) @PathVariable(REQUEST_PARAM_ID) String userId,
 				    @Valid @RequestBody ResetPasswordRequest resetPasswordRequest)
 		throws UserNotFoundException, UserExternallyManagedException, ServiceLayerException {

--- a/studio/src/main/java/org/craftercms/studio/controller/rest/v2/WebdavController.java
+++ b/studio/src/main/java/org/craftercms/studio/controller/rest/v2/WebdavController.java
@@ -55,6 +55,7 @@ import static org.craftercms.studio.controller.rest.ValidationUtils.validateValu
 import static org.craftercms.studio.controller.rest.v2.RequestConstants.*;
 import static org.craftercms.studio.controller.rest.v2.ResultConstants.RESULT_KEY_ITEM;
 import static org.craftercms.studio.controller.rest.v2.ResultConstants.RESULT_KEY_ITEMS;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 /**
  * Rest controller for WebDAV service
@@ -89,7 +90,7 @@ public class WebdavController {
 	 * @throws SiteNotFoundException                 if site does not exist
 	 * @throws ConfigurationProfileNotFoundException if the profile is not found
 	 */
-	@GetMapping("list")
+	@GetMapping(value = "list", produces = APPLICATION_JSON_VALUE)
 	public ResultList<WebDavItem> listItems(
 		@NotBlank @ValidSiteId @RequestParam(REQUEST_PARAM_SITEID) String siteId,
 		@NotBlank @RequestParam(REQUEST_PARAM_PROFILE_ID) String profileId,
@@ -114,7 +115,7 @@ public class WebdavController {
 	 * @throws SiteNotFoundException                 if site does not exist
 	 * @throws ConfigurationProfileNotFoundException if the profile is not found
 	 */
-	@PostMapping("/upload")
+	@PostMapping(value = "/upload", produces = APPLICATION_JSON_VALUE)
 	public ResultOne<WebDavItem> uploadItem(HttpServletRequest request) throws IOException, WebDavException,
 		InvalidParametersException, SiteNotFoundException, ConfigurationProfileNotFoundException, ValidationException {
 		if (!JakartaServletFileUpload.isMultipartContent(request)) {

--- a/studio/src/main/java/org/craftercms/studio/controller/rest/v2/WorkflowController.java
+++ b/studio/src/main/java/org/craftercms/studio/controller/rest/v2/WorkflowController.java
@@ -107,7 +107,7 @@ public class WorkflowController {
 		return toRet;
 	}
 
-	@PostMapping(value = ITEM_STATES, produces = APPLICATION_JSON_VALUE)
+	@PostMapping(value = ITEM_STATES, produces = APPLICATION_JSON_VALUE, consumes = APPLICATION_JSON_VALUE)
 	public Result updateItemStates(@Valid @RequestBody ItemStatesPostRequestBody requestBody)
 		throws SiteNotFoundException {
 		ItemStatesUpdate update = requestBody.getUpdate();
@@ -120,7 +120,7 @@ public class WorkflowController {
 		return result;
 	}
 
-	@PostMapping(value = UPDATE_ITEM_STATES_BY_QUERY, produces = APPLICATION_JSON_VALUE)
+	@PostMapping(value = UPDATE_ITEM_STATES_BY_QUERY, produces = APPLICATION_JSON_VALUE, consumes = APPLICATION_JSON_VALUE)
 	public Result updateItemStatesByQuery(@Valid @RequestBody UpdateItemStatesByQueryRequestBody requestBody)
 		throws SiteNotFoundException, InvalidParametersException {
 		UpdateItemStatesByQueryRequestBody.Query query = requestBody.getQuery();
@@ -173,7 +173,7 @@ public class WorkflowController {
 		return result;
 	}
 
-	@PostMapping(PATH_PARAM_SITE + CANCEL)
+	@PostMapping(value = PATH_PARAM_SITE + CANCEL, consumes = APPLICATION_JSON_VALUE)
 	public Result cancel(@Valid @PathVariable @NotEmpty @ValidSiteId String site,
 						 @Valid @RequestBody ReviewPackageRequestBody cancelPackageRequest)
 		throws ServiceLayerException, AuthenticationException {

--- a/studio/src/main/java/org/craftercms/studio/controller/rest/v2/WorkflowController.java
+++ b/studio/src/main/java/org/craftercms/studio/controller/rest/v2/WorkflowController.java
@@ -150,7 +150,7 @@ public class WorkflowController {
 		return result;
 	}
 
-	@PostMapping(value = PATH_PARAM_SITE + APPROVE, consumes = APPLICATION_JSON_VALUE)
+	@PostMapping(value = PATH_PARAM_SITE + APPROVE, consumes = APPLICATION_JSON_VALUE, produces = APPLICATION_JSON_VALUE)
 	public Result approve(@Valid @PathVariable @NotEmpty @ValidSiteId String site,
 						  @Valid @RequestBody ApproveRequestBody request)
 		throws UserNotFoundException, ServiceLayerException, AuthenticationException {
@@ -162,7 +162,7 @@ public class WorkflowController {
 		return result;
 	}
 
-	@PostMapping(value = PATH_PARAM_SITE + REJECT, consumes = APPLICATION_JSON_VALUE)
+	@PostMapping(value = PATH_PARAM_SITE + REJECT, consumes = APPLICATION_JSON_VALUE, produces = APPLICATION_JSON_VALUE)
 	public Result reject(@Valid @PathVariable @NotEmpty @ValidSiteId String site,
 						 @Valid @RequestBody ReviewPackageRequestBody rejectRequestBody)
 		throws ServiceLayerException, AuthenticationException {
@@ -173,7 +173,7 @@ public class WorkflowController {
 		return result;
 	}
 
-	@PostMapping(value = PATH_PARAM_SITE + CANCEL, consumes = APPLICATION_JSON_VALUE)
+	@PostMapping(value = PATH_PARAM_SITE + CANCEL, consumes = APPLICATION_JSON_VALUE, produces = APPLICATION_JSON_VALUE)
 	public Result cancel(@Valid @PathVariable @NotEmpty @ValidSiteId String site,
 						 @Valid @RequestBody ReviewPackageRequestBody cancelPackageRequest)
 		throws ServiceLayerException, AuthenticationException {

--- a/studio/src/main/java/org/craftercms/studio/controller/rest/v2/aws/AwsMediaConvertController.java
+++ b/studio/src/main/java/org/craftercms/studio/controller/rest/v2/aws/AwsMediaConvertController.java
@@ -50,6 +50,7 @@ import static org.craftercms.studio.controller.rest.v2.RequestConstants.REQUEST_
 import static org.craftercms.studio.controller.rest.v2.RequestConstants.REQUEST_PARAM_SITE_ID;
 import static org.craftercms.studio.controller.rest.v2.ResultConstants.RESULT_KEY_ITEM;
 import static org.craftercms.studio.controller.rest.ValidationUtils.validateValue;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 /**
  * Rest controller for AWS MediaConvert
@@ -78,7 +79,7 @@ public class AwsMediaConvertController {
 	 * @throws SiteNotFoundException                 if the site is not found
 	 * @throws ConfigurationProfileNotFoundException if the profile is not found
 	 */
-	@PostMapping("/upload")
+	@PostMapping(value = "/upload", produces = APPLICATION_JSON_VALUE)
 	public ResultOne<MediaConvertResult> uploadVideo(HttpServletRequest request)
 		throws IOException, AwsException, InvalidParametersException, ConfigurationProfileNotFoundException, SiteNotFoundException, ValidationException {
 		if (!JakartaServletFileUpload.isMultipartContent(request)) {

--- a/studio/src/main/java/org/craftercms/studio/controller/rest/v2/aws/AwsS3Controller.java
+++ b/studio/src/main/java/org/craftercms/studio/controller/rest/v2/aws/AwsS3Controller.java
@@ -57,6 +57,7 @@ import static org.craftercms.studio.controller.rest.ValidationUtils.validateValu
 import static org.craftercms.studio.controller.rest.v2.RequestConstants.*;
 import static org.craftercms.studio.controller.rest.v2.ResultConstants.RESULT_KEY_ITEM;
 import static org.craftercms.studio.controller.rest.v2.ResultConstants.RESULT_KEY_ITEMS;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 /**
  * Rest controller for AWS S3 service.
@@ -88,7 +89,7 @@ public class AwsS3Controller {
 	 * @throws SiteNotFoundException                 if the site is not found
 	 * @throws ConfigurationProfileNotFoundException if the profile is not found
 	 */
-	@GetMapping("/list")
+	@GetMapping(value = "/list", produces = APPLICATION_JSON_VALUE)
 	public ResultList<S3Item> listItems(
 		@ValidSiteId @RequestParam(REQUEST_PARAM_SITEID) String siteId,
 		@ValidateNoTagsParam @RequestParam(REQUEST_PARAM_PROFILE_ID) String profileId,
@@ -115,7 +116,7 @@ public class AwsS3Controller {
 	 * @throws SiteNotFoundException                 if the site is not found
 	 * @throws ConfigurationProfileNotFoundException if the profile is not found
 	 */
-	@PostMapping("/upload")
+	@PostMapping(value = "/upload", produces = APPLICATION_JSON_VALUE)
 	public ResultOne<S3Item> uploadItem(HttpServletRequest request) throws IOException, InvalidParametersException,
 		AwsException, SiteNotFoundException, ConfigurationProfileNotFoundException, ValidationException {
 		if (!JakartaServletFileUpload.isMultipartContent(request)) {

--- a/studio/src/main/resources/crafter/studio/extension/rendering-overlay-context.xml
+++ b/studio/src/main/resources/crafter/studio/extension/rendering-overlay-context.xml
@@ -261,7 +261,6 @@
 		<property name="defaultViews">
 			<list>
 				<ref bean="crafter.jsonView"/>
-				<ref bean="crafter.xmlView"/>
 				<ref bean="studio.binaryView"/>
 			</list>
 		</property>


### PR DESCRIPTION
https://github.com/craftersoftware/craftercms-e/issues/1307
Remove xml responses and return only JSON whenever possible
Force JSON in request bodies
Prevent deserialization unless explicit permission is granted


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * REST endpoints across content, sites, search, workflow, security, monitoring, configuration, and administration now explicitly support JSON request and response formats.
  * GraphQL, upload, marketplace, publishing, repository, and integration endpoints provide clearer JSON content negotiation.
  * XML response handling has been streamlined while preserving JSON and binary response support.
* **Bug Fixes**
  * Improved consistency and predictability when clients send or request JSON through REST APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->