### PR TITLE
#8737 Add support for ftlx and flth freemarker template extensions

### DIFF
--- a/studio/src/main/resources/crafter/studio/database/upgrade/5.0.x/5.0.0.25-to-5.0.0.26.sql
+++ b/studio/src/main/resources/crafter/studio/database/upgrade/5.0.x/5.0.0.25-to-5.0.0.26.sql
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2007-2026 Crafter Software Corporation. All Rights Reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as published by
+ * the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+UPDATE item
+SET system_type = 'renderingTemplate'
+WHERE system_type <> 'folder'
+AND path like '/templates/%'
+AND (path like '%.ftlx' OR path like '%.ftlh') ;

--- a/studio/src/main/resources/crafter/studio/upgrade/5.0.x/config/site-config/site-config-v5.0.0.0.xslt
+++ b/studio/src/main/resources/crafter/studio/upgrade/5.0.x/config/site-config/site-config-v5.0.0.0.xslt
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  * Copyright (C) 2007-2026 Crafter Software Corporation. All Rights Reserved.
+  *
+  * This program is free software: you can redistribute it and/or modify
+  * it under the terms of the GNU General Public License version 3 as published by
+  * the Free Software Foundation.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  * GNU General Public License for more details.
+  *
+  * You should have received a copy of the GNU General Public License
+  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0">
+
+	<!-- to keep the right formatting -->
+	<xsl:output method="xml" indent="yes" />
+	<xsl:strip-space elements="*"/>
+
+	<!-- copy all elements -->
+	<xsl:template match="node() | @*">
+		<!-- insert line breaks before comments -->
+		<xsl:if test="self::comment()">
+			<xsl:text>&#10;</xsl:text>
+		</xsl:if>
+		<xsl:copy>
+			<xsl:apply-templates select="node() | @*"/>
+		</xsl:copy>
+		<!-- insert line breaks after comments -->
+		<xsl:if test="self::comment()">
+			<xsl:text>&#10;</xsl:text>
+		</xsl:if>
+	</xsl:template>
+
+	<!-- Add ftlh and ftlx patterns to /site-config/repository/patterns/pattern-group[@name='rendering-template'] -->
+	<xsl:template match="/site-config/repository/patterns/pattern-group[@name='rendering-template']">
+		<xsl:copy>
+			<xsl:apply-templates select="node() | @*"/>
+			<xsl:if test="not(pattern[contains(text(), '.ftlh')])">
+				<xsl:element name="pattern">
+					<xsl:text>/templates/([^&lt;"]+)\.ftlh</xsl:text>
+				</xsl:element>
+			</xsl:if>
+			<xsl:if test="not(pattern[contains(text(), '.ftlx')])">
+				<xsl:element name="pattern">
+					<xsl:text>/templates/([^&lt;"]+)\.ftlx</xsl:text>
+				</xsl:element>
+			</xsl:if>
+		</xsl:copy>
+	</xsl:template>
+
+</xsl:stylesheet>

--- a/studio/src/main/resources/crafter/studio/upgrade/pipelines.yaml
+++ b/studio/src/main/resources/crafter/studio/upgrade/pipelines.yaml
@@ -919,6 +919,12 @@ configurations:
                         -   type: xsltFileUpgrader
                             template: crafter/studio/upgrade/4.2.x/config/site-config/site-config-v4.2.0.0.xslt
                             commitDetails: Add Component type pattern
+                -   currentVersion: 4.2.0.0
+                    nextVersion: 5.0.0.0
+                    operations:
+                        -   type: xsltFileUpgrader
+                            template: crafter/studio/upgrade/5.0.x/config/site-config/site-config-v5.0.0.0.xslt
+                            commitDetails: Add FTLH and FTLX to rendering template patterns
 
     permission-mappings-config:
         module: studio

--- a/studio/src/main/resources/crafter/studio/upgrade/pipelines.yaml
+++ b/studio/src/main/resources/crafter/studio/upgrade/pipelines.yaml
@@ -663,6 +663,11 @@ pipelines:
                         path: /configuration/global-permission-mappings-config.xml
                         template: crafter/studio/upgrade/5.0.x/system/global-permission-mappings-config-v5.0.0.25.xslt
                         commitDetails: Remove unused permissions
+            -   currentVersion: 5.0.0.25
+                nextVersion: 5.0.0.26
+                operations:
+                    -   type: dbScriptUpgrader
+                        filename: upgrade/5.0.x/5.0.0.25-to-5.0.0.26.sql
 
 
 

--- a/studio/src/main/webapp/repo-bootstrap/global/blueprints/1000_website_editorial/config/studio/site-config.xml
+++ b/studio/src/main/webapp/repo-bootstrap/global/blueprints/1000_website_editorial/config/studio/site-config.xml
@@ -168,6 +168,8 @@
 
 			<pattern-group name="rendering-template">
 				<pattern>/templates/([^&lt;"]+)\.ftl</pattern>
+				<pattern>/templates/([^&lt;"]+)\.ftlh</pattern>
+				<pattern>/templates/([^&lt;"]+)\.ftlx</pattern>
 			</pattern-group>
 
 			<pattern-group name="scripts">

--- a/studio/src/main/webapp/repo-bootstrap/global/blueprints/2000_headless_store/config/studio/site-config.xml
+++ b/studio/src/main/webapp/repo-bootstrap/global/blueprints/2000_headless_store/config/studio/site-config.xml
@@ -169,6 +169,8 @@
 
 			<pattern-group name="rendering-template">
 				<pattern>/templates/([^&lt;"]+)\.ftl</pattern>
+				<pattern>/templates/([^&lt;"]+)\.ftlh</pattern>
+				<pattern>/templates/([^&lt;"]+)\.ftlx</pattern>
 			</pattern-group>
 
 			<pattern-group name="scripts">

--- a/studio/src/main/webapp/repo-bootstrap/global/blueprints/4000_empty/config/studio/site-config.xml
+++ b/studio/src/main/webapp/repo-bootstrap/global/blueprints/4000_empty/config/studio/site-config.xml
@@ -168,6 +168,8 @@
 
 			<pattern-group name="rendering-template">
 				<pattern>/templates/([^&lt;"]+)\.ftl</pattern>
+				<pattern>/templates/([^&lt;"]+)\.ftlh</pattern>
+				<pattern>/templates/([^&lt;"]+)\.ftlx</pattern>
 			</pattern-group>
 
 			<pattern-group name="scripts">

--- a/studio/src/main/webapp/repo-bootstrap/global/blueprints/5000_headless_blog/config/studio/site-config.xml
+++ b/studio/src/main/webapp/repo-bootstrap/global/blueprints/5000_headless_blog/config/studio/site-config.xml
@@ -169,6 +169,8 @@
 
 			<pattern-group name="rendering-template">
 				<pattern>/templates/([^&lt;"]+)\.ftl</pattern>
+				<pattern>/templates/([^&lt;"]+)\.ftlh</pattern>
+				<pattern>/templates/([^&lt;"]+)\.ftlx</pattern>
 			</pattern-group>
 
 			<pattern-group name="scripts">

--- a/studio/src/test/java/org/craftercms/studio/XsltTest.java
+++ b/studio/src/test/java/org/craftercms/studio/XsltTest.java
@@ -426,6 +426,29 @@ public class XsltTest {
 		testXsltTemplate(template, content, expected, params);
 	}
 
+	@DataProvider(name = "siteConfig5000TestData")
+	public Object[][] siteConfig5000TestData() {
+		return new Object[][]{
+			new Object[] {
+				new ClassPathResource("crafter/studio/upgrade/5.0.x/config/site-config/site-config-v5.0.0.0.xslt"),
+				new ClassPathResource("crafter/studio/upgrade/xslt/site-config/5.0.0.0/add/input.xml"),
+				new ClassPathResource("crafter/studio/upgrade/xslt/site-config/5.0.0.0/add/expected.xml"),
+				emptyMap()
+			},
+			new Object[] {
+				new ClassPathResource("crafter/studio/upgrade/5.0.x/config/site-config/site-config-v5.0.0.0.xslt"),
+				new ClassPathResource("crafter/studio/upgrade/xslt/site-config/5.0.0.0/existed/input.xml"),
+				new ClassPathResource("crafter/studio/upgrade/xslt/site-config/5.0.0.0/existed/expected.xml"),
+				emptyMap()
+			}
+		};
+	}
+
+	@Test(dataProvider = "siteConfig5000TestData")
+	public void siteConfig5000Test(Resource template, Resource content, Resource expected, Map<String, Object> params) throws IOException, TransformerException {
+		testXsltTemplate(template, content, expected, params);
+	}
+
 	@DataProvider(name = "globalPermissions50010TestData")
 	public Object[][] globalPermissions50010TestData() {
 		return new Object[][]{

--- a/studio/src/test/resources/crafter/studio/upgrade/xslt/site-config/5.0.0.0/add/expected.xml
+++ b/studio/src/test/resources/crafter/studio/upgrade/xslt/site-config/5.0.0.0/add/expected.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (C) 2007-2026 Crafter Software Corporation. All Rights Reserved.
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License version 3 as published by
+  ~ the Free Software Foundation.
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<!-- site-config.xml
+
+    This contains the primary site configuration.
+
+-->
+<site-config>
+	<version>4.2.0.0</version>
+	<wem-project>{siteName}</wem-project>
+	<display-name>{siteName}</display-name>
+
+	<repository rootPrefix="/site">
+		<patterns>
+			<pattern-group name="page">
+				<pattern>/site/website/([^&lt;]+)\.xml</pattern>
+			</pattern-group>
+
+			<pattern-group name="component">
+				<pattern>/site/components/([^&lt;]+)\.xml</pattern>
+			</pattern-group>
+
+			<pattern-group name="asset">
+				<pattern>/static-assets/([^&lt;"']+)</pattern>
+			</pattern-group>
+
+			<pattern-group name="rendering-template">
+				<pattern>/templates/([^&lt;"]+)\.ftl</pattern>
+				<pattern>/templates/([^&lt;"]+)\.ftlh</pattern>
+				<pattern>/templates/([^&lt;"]+)\.ftlx</pattern>
+			</pattern-group>
+
+			<pattern-group name="scripts">
+				<pattern>/scripts/([^&lt;"]+)\.groovy</pattern>
+			</pattern-group>
+
+			<pattern-group name="config">
+				<pattern>/config/(?!studio/content-types/)([^&lt;"']+)\.xml</pattern>
+			</pattern-group>
+		</patterns>
+	</repository>
+</site-config>

--- a/studio/src/test/resources/crafter/studio/upgrade/xslt/site-config/5.0.0.0/add/input.xml
+++ b/studio/src/test/resources/crafter/studio/upgrade/xslt/site-config/5.0.0.0/add/input.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (C) 2007-2026 Crafter Software Corporation. All Rights Reserved.
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License version 3 as published by
+  ~ the Free Software Foundation.
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<!-- site-config.xml
+
+    This contains the primary site configuration.
+
+-->
+<site-config>
+	<version>4.2.0.0</version>
+	<wem-project>{siteName}</wem-project>
+	<display-name>{siteName}</display-name>
+
+	<repository rootPrefix="/site">
+		<patterns>
+			<pattern-group name="page">
+				<pattern>/site/website/([^&lt;]+)\.xml</pattern>
+			</pattern-group>
+
+			<pattern-group name="component">
+				<pattern>/site/components/([^&lt;]+)\.xml</pattern>
+			</pattern-group>
+
+			<pattern-group name="asset">
+				<pattern>/static-assets/([^&lt;"']+)</pattern>
+			</pattern-group>
+
+			<pattern-group name="rendering-template">
+				<pattern>/templates/([^&lt;"]+)\.ftl</pattern>
+			</pattern-group>
+
+			<pattern-group name="scripts">
+				<pattern>/scripts/([^&lt;"]+)\.groovy</pattern>
+			</pattern-group>
+
+			<pattern-group name="config">
+				<pattern>/config/(?!studio/content-types/)([^&lt;"']+)\.xml</pattern>
+			</pattern-group>
+		</patterns>
+	</repository>
+</site-config>

--- a/studio/src/test/resources/crafter/studio/upgrade/xslt/site-config/5.0.0.0/existed/expected.xml
+++ b/studio/src/test/resources/crafter/studio/upgrade/xslt/site-config/5.0.0.0/existed/expected.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (C) 2007-2026 Crafter Software Corporation. All Rights Reserved.
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License version 3 as published by
+  ~ the Free Software Foundation.
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<!-- site-config.xml
+
+    This contains the primary site configuration.
+
+-->
+<site-config>
+	<version>4.2.0.0</version>
+	<wem-project>{siteName}</wem-project>
+	<display-name>{siteName}</display-name>
+
+	<repository rootPrefix="/site">
+		<patterns>
+			<pattern-group name="page">
+				<pattern>/site/website/([^&lt;]+)\.xml</pattern>
+			</pattern-group>
+
+			<pattern-group name="component">
+				<pattern>/site/components/([^&lt;]+)\.xml</pattern>
+			</pattern-group>
+
+			<pattern-group name="asset">
+				<pattern>/static-assets/([^&lt;"']+)</pattern>
+			</pattern-group>
+
+			<pattern-group name="rendering-template">
+				<pattern>/templates/([^&lt;"]+)\.ftl</pattern>
+				<pattern>/templates/([^&lt;"]+)\.ftlh</pattern>
+				<pattern>/templates/([^&lt;"]+)\.ftlx</pattern>
+			</pattern-group>
+
+			<pattern-group name="scripts">
+				<pattern>/scripts/([^&lt;"]+)\.groovy</pattern>
+			</pattern-group>
+
+			<pattern-group name="config">
+				<pattern>/config/(?!studio/content-types/)([^&lt;"']+)\.xml</pattern>
+			</pattern-group>
+		</patterns>
+	</repository>
+</site-config>

--- a/studio/src/test/resources/crafter/studio/upgrade/xslt/site-config/5.0.0.0/existed/input.xml
+++ b/studio/src/test/resources/crafter/studio/upgrade/xslt/site-config/5.0.0.0/existed/input.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (C) 2007-2026 Crafter Software Corporation. All Rights Reserved.
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License version 3 as published by
+  ~ the Free Software Foundation.
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<!-- site-config.xml
+
+    This contains the primary site configuration.
+
+-->
+<site-config>
+	<version>4.2.0.0</version>
+	<wem-project>{siteName}</wem-project>
+	<display-name>{siteName}</display-name>
+
+	<repository rootPrefix="/site">
+		<patterns>
+			<pattern-group name="page">
+				<pattern>/site/website/([^&lt;]+)\.xml</pattern>
+			</pattern-group>
+
+			<pattern-group name="component">
+				<pattern>/site/components/([^&lt;]+)\.xml</pattern>
+			</pattern-group>
+
+			<pattern-group name="asset">
+				<pattern>/static-assets/([^&lt;"']+)</pattern>
+			</pattern-group>
+
+			<pattern-group name="rendering-template">
+				<pattern>/templates/([^&lt;"]+)\.ftl</pattern>
+				<pattern>/templates/([^&lt;"]+)\.ftlh</pattern>
+				<pattern>/templates/([^&lt;"]+)\.ftlx</pattern>
+			</pattern-group>
+
+			<pattern-group name="scripts">
+				<pattern>/scripts/([^&lt;"]+)\.groovy</pattern>
+			</pattern-group>
+
+			<pattern-group name="config">
+				<pattern>/config/(?!studio/content-types/)([^&lt;"']+)\.xml</pattern>
+			</pattern-group>
+		</patterns>
+	</repository>
+</site-config>


### PR DESCRIPTION
https://github.com/craftersoftware/craftercms/issues/8737
Add support for ftlx and flth freemarker template extensions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for recognizing `.ftlh` and `.ftlx` files as rendering templates.
  * Updated default site configurations to include the new template formats.
* **Upgrade**
  * Existing sites are automatically updated to recognize `.ftlh` and `.ftlx` templates.
  * Template files in existing repositories are correctly classified during upgrade.
* **Tests**
  * Added coverage for site-configuration upgrades, including new and existing configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->