### PR TITLE
Add new event to separate site creation from site bootstrap ready event

### DIFF
--- a/studio-ui/ui/app/src/components/GlobalDialogManager/GlobalDialogManager.tsx
+++ b/studio-ui/ui/app/src/components/GlobalDialogManager/GlobalDialogManager.tsx
@@ -21,7 +21,7 @@ import { useDispatch } from 'react-redux';
 import { isPlainObject } from '../../utils/object';
 import { SnackbarKey, useSnackbar } from 'notistack';
 import { getHostToHostBus } from '../../utils/subjects';
-import { blockUI, newProjectReady, showSystemNotification, unblockUI } from '../../state/actions/system';
+import { blockUI, newProjectReady, projectBootstrapReady, showSystemNotification, unblockUI } from '../../state/actions/system';
 import Launcher from '../Launcher/Launcher';
 import useSelection from '../../hooks/useSelection';
 import { useWithPendingChangesCloseRequest } from '../../hooks/useWithPendingChangesCloseRequest';
@@ -138,7 +138,7 @@ function GlobalDialogManager() {
   useEffect(() => {
     const subscription = getHostToHostBus()
       .pipe(
-        filter((e: StandardAction<ProjectLifecycleEvent>) => e.type === newProjectReady.type),
+        filter((e: StandardAction<ProjectLifecycleEvent>) => e.type === newProjectReady.type || e.type === projectBootstrapReady.type),
         switchMap((e) =>
           // Not the most efficient approach to (re)fetch all sites (which already occurs when a new site is created), but it's not possible to
           // look site by uuid or to sync this even with the completion of the background fetch of the sites.

--- a/studio-ui/ui/app/src/models/ProjectLifecycleEvent.ts
+++ b/studio-ui/ui/app/src/models/ProjectLifecycleEvent.ts
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-export interface ProjectLifecycleEvent<T = 'SITE_READY_EVENT' | 'SITE_DELETING_EVENT' | 'SITE_DELETED_EVENT'> {
+export interface ProjectLifecycleEvent<T = 'SITE_READY_EVENT' | 'SITE_BOOTSTRAP_READY_EVENT' | 'SITE_DELETING_EVENT' | 'SITE_DELETED_EVENT'> {
   timestamp: number;
   siteUuid: string;
   eventType: T;

--- a/studio-ui/ui/app/src/state/actions/system.ts
+++ b/studio-ui/ui/app/src/state/actions/system.ts
@@ -165,6 +165,7 @@ export const globalSocketStatus = /*#__PURE__*/ createAction<{ connected: boolea
 
 export const newProjectReady =
   /*#__PURE__*/ createAction<ProjectLifecycleEvent<'SITE_READY_EVENT'>>('SITE_READY_EVENT');
+export const projectBootstrapReady = /*#__PURE__*/ createAction<ProjectLifecycleEvent<'SITE_BOOTSTRAP_READY_EVENT'>>('SITE_BOOTSTRAP_READY_EVENT');
 export const projectBeingDeleted =
   /*#__PURE__*/ createAction<ProjectLifecycleEvent<'SITE_DELETING_EVENT'>>('SITE_DELETING_EVENT');
 export const projectDeleted =

--- a/studio-ui/ui/app/src/state/epics/system.ts
+++ b/studio-ui/ui/app/src/state/epics/system.ts
@@ -54,7 +54,8 @@ import {
   showUnlockItemSuccessNotification,
   storeInitialized,
   closeSiteSocket,
-  emitSystemEvents
+  emitSystemEvents,
+  projectBootstrapReady
 } from '../actions/system';
 import { CrafterCMSEpic } from '../store';
 import {
@@ -464,10 +465,10 @@ const systemEpics: CrafterCMSEpic[] = [
       exhaustMap(() => fetchGlobalMenuItems().pipe(map(fetchGlobalMenuComplete), catchAjaxError(fetchGlobalMenuFailed)))
     ),
   // endregion
-  // region newProjectReady
+  // region newProjectReady, projectBootstrapReady
   (action$) =>
     action$.pipe(
-      ofType(newProjectReady.type),
+      ofType(newProjectReady.type, projectBootstrapReady.type),
       map(() => fetchSites())
     ),
   // endregion

--- a/studio-ui/ui/app/src/state/store.ts
+++ b/studio-ui/ui/app/src/state/store.ts
@@ -33,6 +33,7 @@ import {
   emitSystemEvent,
   globalSocketStatus,
   newProjectReady,
+  projectBootstrapReady,
   projectBeingDeleted,
   projectDeleted,
   siteSocketStatus,
@@ -100,6 +101,7 @@ export function getStore(): Observable<CrafterCMSStore> {
                       ].includes(action.type) ||
                       // Projects lifecycle events (created, deleted, etc.) should always go through.
                       payload.eventType === newProjectReady.type ||
+                      payload.eventType === projectBootstrapReady.type ||
                       payload.eventType === projectBeingDeleted.type ||
                       payload.eventType === projectDeleted.type ||
                       // No siteId on the event should be applicable to all sites.

--- a/studio/src/main/java/org/craftercms/studio/api/v2/event/site/SiteBootstrapReadyEvent.java
+++ b/studio/src/main/java/org/craftercms/studio/api/v2/event/site/SiteBootstrapReadyEvent.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2007-2026 Crafter Software Corporation. All Rights Reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as published by
+ * the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.craftercms.studio.api.v2.event.site;
+
+/**
+ * Event triggered when a site bootstrap is complete
+ *
+ */
+public class SiteBootstrapReadyEvent extends SiteLifecycleEvent {
+
+    public SiteBootstrapReadyEvent(final String siteId, final String siteUuid) {
+        super(siteId, siteUuid);
+    }
+
+    @Override
+    public String getEventType() {
+        return "SITE_BOOTSTRAP_READY_EVENT";
+    }
+}

--- a/studio/src/main/java/org/craftercms/studio/impl/v2/utils/spring/context/SiteBootstrapStateProviderImpl.java
+++ b/studio/src/main/java/org/craftercms/studio/impl/v2/utils/spring/context/SiteBootstrapStateProviderImpl.java
@@ -17,6 +17,7 @@ package org.craftercms.studio.impl.v2.utils.spring.context;
 
 import org.craftercms.studio.api.v2.dal.Site;
 import org.craftercms.studio.api.v2.dal.SiteDAO;
+import org.craftercms.studio.api.v2.event.site.SiteBootstrapReadyEvent;
 import org.craftercms.studio.api.v2.event.site.SiteReadyEvent;
 import org.craftercms.studio.api.v2.utils.spring.context.SiteBootstrapStateProvider;
 import org.jspecify.annotations.NonNull;
@@ -51,7 +52,7 @@ public class SiteBootstrapStateProviderImpl implements SiteBootstrapStateProvide
 	public void markSiteAsReady(String siteId) {
 		getReadySites().add(siteId);
 		Site site = siteDAO.getSite(siteId);
-		applicationEventPublisher.publishEvent(new SiteReadyEvent(siteId, site.getSiteUuid()));
+		applicationEventPublisher.publishEvent(new SiteBootstrapReadyEvent(siteId, site.getSiteUuid()));
 	}
 
 	@Override


### PR DESCRIPTION
Add new event to separate site creation from site bootstrap ready event
https://github.com/craftersoftware/craftercms/issues/8953

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a site lifecycle notification for completed site bootstrapping, including the site identifier and unique ID.
  * Site creation and refresh workflows now respond to bootstrap completion events.
  * Site listings automatically refresh when bootstrapping finishes.

* **Bug Fixes**
  * Improved readiness reporting by distinguishing bootstrap completion from general site readiness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->