### PR TITLE
Site exists API require logged in user

### DIFF
--- a/studio/src/main/api/studio-api.yaml
+++ b/studio/src/main/api/studio-api.yaml
@@ -2171,7 +2171,7 @@ paths:
             summary: Check if a site exists
             description: |
                     Module: Studio <br>
-                    Required permission "site_member"
+                    Required permission "LOGGED_IN"
             operationId: siteExists
             tags:
                 - sites

--- a/studio/src/main/java/org/craftercms/studio/impl/v2/service/site/SitesServiceImpl.java
+++ b/studio/src/main/java/org/craftercms/studio/impl/v2/service/site/SitesServiceImpl.java
@@ -109,7 +109,6 @@ public class SitesServiceImpl implements SitesService {
 	}
 
 	@Override
-	@HasPermission(type = DefaultPermission.class, action = PERMISSION_CONTENT_READ)
 	public boolean exists(@SiteId String siteId) {
 		return sitesServiceInternal.exists(siteId);
 	}


### PR DESCRIPTION
https://github.com/craftersoftware/craftercms/issues/8802
Site exists API require logged in user

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated site existence checks to require only a logged-in session.
  * Users no longer need site membership or content-read permissions to verify whether a site exists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->