### PR TITLE
Release 4.5.2

### DIFF
--- a/docker-compose/authoring/docker-compose.yml
+++ b/docker-compose/authoring/docker-compose.yml
@@ -30,7 +30,7 @@ services:
       - search_data:/usr/share/opensearch/data
       - search_logs:/usr/share/opensearch/logs
   tomcat:
-    image: craftercms/authoring_tomcat:4.5.2 # craftercms version flag
+    image: craftercms/authoring_tomcat:4.5.3-SNAPSHOT # craftercms version flag
     platform: linux/amd64
     depends_on:
       - search
@@ -49,7 +49,7 @@ services:
       - ES_HOST=search
       - ES_PORT=9200
   deployer:
-    image: craftercms/deployer:4.5.2 # craftercms version flag
+    image: craftercms/deployer:4.5.3-SNAPSHOT # craftercms version flag
     platform: linux/amd64
     depends_on:
       - search

--- a/docker-compose/authoring/docker-compose.yml
+++ b/docker-compose/authoring/docker-compose.yml
@@ -14,7 +14,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 services:
   search:
-    image: opensearchproject/opensearch:3.6.0
+    image: opensearchproject/opensearch:3.8.0
     ports:
       - 9201:9200
     environment:

--- a/docker-compose/delivery/docker-compose.yml
+++ b/docker-compose/delivery/docker-compose.yml
@@ -30,7 +30,7 @@ services:
       - search_data:/usr/share/opensearch/data
       - search_logs:/usr/share/opensearch/logs
   tomcat:
-    image: craftercms/delivery_tomcat:4.5.2 # craftercms version flag
+    image: craftercms/delivery_tomcat:4.5.3-SNAPSHOT # craftercms version flag
     platform: linux/amd64
     depends_on:
       - search
@@ -47,7 +47,7 @@ services:
       - ES_HOST=search
       - ES_PORT=9200
   deployer:
-    image: craftercms/deployer:4.5.2 # craftercms version flag
+    image: craftercms/deployer:4.5.3-SNAPSHOT # craftercms version flag
     platform: linux/amd64
     depends_on:
       - search

--- a/docker-compose/delivery/docker-compose.yml
+++ b/docker-compose/delivery/docker-compose.yml
@@ -14,7 +14,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 services:
   search:
-    image: opensearchproject/opensearch:3.6.0
+    image: opensearchproject/opensearch:3.8.0
     ports:
       - 9202:9200
     environment:

--- a/docker-compose/serverless/s3/delivery/docker-compose.yml
+++ b/docker-compose/serverless/s3/delivery/docker-compose.yml
@@ -14,7 +14,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 services:
   tomcat:
-    image: craftercms/delivery_tomcat:4.5.2 # craftercms version flag
+    image: craftercms/delivery_tomcat:4.5.3-SNAPSHOT # craftercms version flag
     platform: linux/amd64
     ports:
       - 9080:8080

--- a/global-settings.gradle
+++ b/global-settings.gradle
@@ -92,7 +92,7 @@ project.ext.set("startCommand", project.hasProperty("debug") ? "debug" : "start"
 project.ext.set("stopCommand", "stop")
 project.ext.set("statusCommand", "status")
 project.ext.set("gitRemote", getPropertySafelyWithDefaults("gitRemote", "origin"))
-project.ext.set("gitBranch", "v4.5.2") // craftercms branch flag
+project.ext.set("gitBranch", "support/4.x") // craftercms branch flag
 project.ext.set("bundlesDir", getPropertySafelyWithDefaults(bundlesDir, "./bundles"))
 project.ext.set("crafterCmd", getPropertySafelyWithDefaults("crafterCmd", "./crafter.sh"))
 project.ext.set("currentPlatform", getPropertySafelyWithDefaults("currentPlatform", SystemUtils.IS_OS_MAC_OSX ? "darwin" : "linux"))

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 # Versions
 # Main Versions
 org.gradle.daemon=true
-craftercmsVersion=4.5.2
+craftercmsVersion=4.5.3-SNAPSHOT
 javaVersion=21
 mongodbVersion=8.0.1
 mongoshVersion=1.8.0

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,7 +14,7 @@
 #
 
 [versions]
-craftercms = "4.5.2"
+craftercms = "4.5.3-SNAPSHOT"
 java = "21"
 spring = "6.2.19"
 commons-lang3 = "3.20.0"


### PR DESCRIPTION
Release 4.5.2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Updated Crafter CMS to version 4.5.3-SNAPSHOT across authoring, delivery, and serverless deployment configurations.
  * Updated OpenSearch to version 3.8.0.
  * Updated the default source branch used by builds to `support/4.x`.
  * Existing explicit branch overrides remain supported.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->