### PR TITLE
Build scripts fixes

### DIFF
--- a/gradle/maven-publish.gradle
+++ b/gradle/maven-publish.gradle
@@ -33,7 +33,7 @@ def configureMavenPublishing = {
 
 	def gprUser = System.getenv('GITHUB_ACTOR') ?: findProperty('gpr.user')
 	def gprKey = System.getenv('GITHUB_TOKEN') ?: System.getenv('GPR_TOKEN') ?: findProperty('gpr.key')
-	def gprOwner = findProperty('gpr.owner') ?: 'craftercms'
+	def gprOwner = findProperty('gpr.owner') ?: 'craftersoftware'
 	def gprRepo = findProperty('gpr.repo') ?: 'craftercms'
 
 	publishing {

--- a/release.gradle
+++ b/release.gradle
@@ -117,7 +117,8 @@ ext.runReleaseBundleMatrix = { String s3Path ->
 
 /** True if the named executable is on PATH. */
 ext.commandLineToolAvailable = { String tool ->
-	def proc = "command -v ${tool}".execute()
+	logger.debug "Checking '${tool}' is available on PATH"
+	def proc = ['sh', '-c', "command -v ${tool}"].execute()
 	proc.waitFor()
 	return proc.exitValue() == 0
 }


### PR DESCRIPTION
Fix github repository owner for maven publishing
Fix ext.commandLineToolAvailable function to run a shell
https://github.com/craftersoftware/craftercms-e/issues/1315
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved command availability checks for more reliable build and release operations.
  * Updated the default GitHub Packages publishing owner while retaining the existing repository default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->