### PR TITLE
[5424] Show 'show disabled users' toggle when there are no search results

### DIFF
--- a/studio-ui/ui/app/src/components/GroupManagement/GroupManagement.tsx
+++ b/studio-ui/ui/app/src/components/GroupManagement/GroupManagement.tsx
@@ -31,7 +31,6 @@ import { useWithPendingChangesCloseRequest } from '../../hooks/useWithPendingCha
 import SearchBar from '../SearchBar';
 import useDebouncedInput from '../../hooks/useDebouncedInput';
 import { ApiResponseErrorState } from '../ApiResponseErrorState';
-import { EmptyState } from '../EmptyState';
 
 export function GroupManagement() {
 	const [offset, setOffset] = useState(0);

--- a/studio-ui/ui/app/src/components/GroupManagement/GroupManagement.tsx
+++ b/studio-ui/ui/app/src/components/GroupManagement/GroupManagement.tsx
@@ -147,16 +147,12 @@ export function GroupManagement() {
 			) : fetching ? (
 				<GroupsGridSkeletonTable numOfItems={limit} />
 			) : groups ? (
-				groups.length ? (
-					<GroupsGridUI
-						groups={groups}
-						onRowClicked={onRowClicked}
-						onPageChange={onPageChange}
-						onRowsPerPageChange={onRowsPerPageChange}
-					/>
-				) : (
-					<EmptyState title={<FormattedMessage id="groupsGrid.emptyStateMessage" defaultMessage="No Groups Found" />} />
-				)
+				<GroupsGridUI
+					groups={groups}
+					onRowClicked={onRowClicked}
+					onPageChange={onPageChange}
+					onRowsPerPageChange={onRowsPerPageChange}
+				/>
 			) : (
 				<></>
 			)}

--- a/studio-ui/ui/app/src/components/GroupsGrid/GroupsGridUI.tsx
+++ b/studio-ui/ui/app/src/components/GroupsGrid/GroupsGridUI.tsx
@@ -27,6 +27,7 @@ import Group from '../../models/Group';
 import GlobalAppGridRow from '../GlobalAppGridRow';
 import GlobalAppGridCell from '../GlobalAppGridCell';
 import Box from '@mui/material/Box';
+import { EmptyState } from '../EmptyState';
 
 export interface GroupsGridUIProps {
 	groups: PagedArray<Group>;
@@ -57,20 +58,30 @@ export function GroupsGridUI(props: GroupsGridUIProps) {
 						</GlobalAppGridRow>
 					</TableHead>
 					<TableBody>
-						{groups.map((group, i) => (
-							<GlobalAppGridRow key={group.id} onClick={() => onRowClicked(group)}>
-								<GlobalAppGridCell align="left" className="width25">
-									<Typography variant="body2" noWrap title={group.name}>
-										{group.name}
-									</Typography>
-								</GlobalAppGridCell>
-								<GlobalAppGridCell align="left">
-									<Typography variant="body2" sx={{ wordWrap: 'break-word' }}>
-										{group.desc}
-									</Typography>
+						{groups?.length ? (
+							groups.map((group, i) => (
+								<GlobalAppGridRow key={group.id} onClick={() => onRowClicked(group)}>
+									<GlobalAppGridCell align="left" className="width25">
+										<Typography variant="body2" noWrap title={group.name}>
+											{group.name}
+										</Typography>
+									</GlobalAppGridCell>
+									<GlobalAppGridCell align="left">
+										<Typography variant="body2" sx={{ wordWrap: 'break-word' }}>
+											{group.desc}
+										</Typography>
+									</GlobalAppGridCell>
+								</GlobalAppGridRow>
+							))
+						) : (
+							<GlobalAppGridRow className="hoverDisabled">
+								<GlobalAppGridCell colSpan={2} align="center">
+									<EmptyState
+										title={<FormattedMessage id="groupsGrid.emptyStateMessage" defaultMessage="No Groups Found" />}
+									/>
 								</GlobalAppGridCell>
 							</GlobalAppGridRow>
-						))}
+						)}
 					</TableBody>
 				</Table>
 			</TableContainer>

--- a/studio-ui/ui/app/src/components/UserManagement/UserManagement.tsx
+++ b/studio-ui/ui/app/src/components/UserManagement/UserManagement.tsx
@@ -32,7 +32,6 @@ import Paper from '@mui/material/Paper';
 import { useEnhancedDialogState } from '../../hooks/useEnhancedDialogState';
 import { useWithPendingChangesCloseRequest } from '../../hooks/useWithPendingChangesCloseRequest';
 import { ApiResponseErrorState } from '../ApiResponseErrorState';
-import { EmptyState } from '../EmptyState';
 import { useActiveUser } from '../../hooks/useActiveUser';
 import { getStoredShowDisabledUsers, setStoredShowDisabledUsers } from '../../utils/state';
 

--- a/studio-ui/ui/app/src/components/UserManagement/UserManagement.tsx
+++ b/studio-ui/ui/app/src/components/UserManagement/UserManagement.tsx
@@ -164,18 +164,14 @@ export function UserManagement(props: UserManagementProps) {
 			) : fetching ? (
 				<UsersGridSkeletonTable numOfItems={limit} />
 			) : users ? (
-				users.length ? (
-					<UsersGridUI
-						users={users}
-						onRowClicked={onRowClicked}
-						onPageChange={onPageChange}
-						onRowsPerPageChange={onRowsPerPageChange}
-						showDisabled={showDisabled}
-						onShowDisabledChange={onShowDisabledChange}
-					/>
-				) : (
-					<EmptyState title={<FormattedMessage id="usersGrid.emptyStateMessage" defaultMessage="No Users Found" />} />
-				)
+				<UsersGridUI
+					users={users}
+					onRowClicked={onRowClicked}
+					onPageChange={onPageChange}
+					onRowsPerPageChange={onRowsPerPageChange}
+					showDisabled={showDisabled}
+					onShowDisabledChange={onShowDisabledChange}
+				/>
 			) : (
 				<></>
 			)}

--- a/studio-ui/ui/app/src/components/UsersGrid/UsersGridUI.tsx
+++ b/studio-ui/ui/app/src/components/UsersGrid/UsersGridUI.tsx
@@ -31,6 +31,7 @@ import Box from '@mui/material/Box';
 import Chip from '@mui/material/Chip';
 import Checkbox from '@mui/material/Checkbox';
 import FormControlLabel from '@mui/material/FormControlLabel';
+import { EmptyState } from '../EmptyState';
 
 export interface UsersGridUIProps {
 	users: PagedArray<User>;
@@ -87,30 +88,40 @@ export function UsersGridUI(props: UsersGridUIProps) {
 						</GlobalAppGridRow>
 					</TableHead>
 					<TableBody>
-						{users?.map((user) => (
-							<GlobalAppGridRow key={user.id} onClick={() => onRowClicked(user)}>
-								<GlobalAppGridCell align="center" className="avatar">
-									<Avatar sx={{ margin: '0 auto' }}>
-										{user.firstName.charAt(0)}
-										{user.lastName?.charAt(0) ?? ''}
-									</Avatar>
-								</GlobalAppGridCell>
-								<GlobalAppGridCell align="left" className="pl20 width20">
-									{user.firstName} {user.lastName}
-								</GlobalAppGridCell>
-								<GlobalAppGridCell align="left" className="width20">
-									<Typography variant="body2" noWrap title={user.username}>
-										{user.username}
-									</Typography>
-								</GlobalAppGridCell>
-								<GlobalAppGridCell align="left" className="width40">
-									{user.email}
-								</GlobalAppGridCell>
-								<GlobalAppGridCell align="right" className="width20">
-									{!user.enabled && <Chip label={<FormattedMessage defaultMessage="Disabled" />} size="small" />}
+						{users?.length ? (
+							users.map((user) => (
+								<GlobalAppGridRow key={user.id} onClick={() => onRowClicked(user)}>
+									<GlobalAppGridCell align="center" className="avatar">
+										<Avatar sx={{ margin: '0 auto' }}>
+											{user.firstName.charAt(0)}
+											{user.lastName?.charAt(0) ?? ''}
+										</Avatar>
+									</GlobalAppGridCell>
+									<GlobalAppGridCell align="left" className="pl20 width20">
+										{user.firstName} {user.lastName}
+									</GlobalAppGridCell>
+									<GlobalAppGridCell align="left" className="width20">
+										<Typography variant="body2" noWrap title={user.username}>
+											{user.username}
+										</Typography>
+									</GlobalAppGridCell>
+									<GlobalAppGridCell align="left" className="width40">
+										{user.email}
+									</GlobalAppGridCell>
+									<GlobalAppGridCell align="right" className="width20">
+										{!user.enabled && <Chip label={<FormattedMessage defaultMessage="Disabled" />} size="small" />}
+									</GlobalAppGridCell>
+								</GlobalAppGridRow>
+							))
+						) : (
+							<GlobalAppGridRow className="hoverDisabled">
+								<GlobalAppGridCell colSpan={5} align="center">
+									<EmptyState
+										title={<FormattedMessage id="usersGrid.emptyStateMessage" defaultMessage="No Users Found" />}
+									/>
 								</GlobalAppGridCell>
 							</GlobalAppGridRow>
-						))}
+						)}
 					</TableBody>
 				</Table>
 			</TableContainer>


### PR DESCRIPTION
https://github.com/craftersoftware/craftercms/issues/5424

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Group and user management tables now load consistently, including when no records are available.
  * Added clear “No Groups Found” and empty-state messaging for groups and users.
  * Existing group and user listings remain unchanged when records are present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->