### PR TITLE
Javadoc related gradle tasks and configs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,7 @@ apply from: "deploy.gradle"
 apply from: "run.gradle"
 apply from: "docker.gradle"
 apply from: "release.gradle"
+apply from: "gradle/javadoc.gradle"
 
 task splash() {
 	description = 'Displays splash screen'
@@ -192,5 +193,15 @@ task bundle() {
 }
 
 gradle.buildFinished {
-	project.buildDir.deleteDir()
+	// The root build dir only holds throwaway output, except for the aggregated javadoc site
+	def rootBuildDir = project.layout.buildDirectory.get().asFile
+	def keep = aggregateJavadocDirName.tokenize('/').first()
+	rootBuildDir.listFiles()?.each { file ->
+		if (file.name != keep) {
+			file.directory ? file.deleteDir() : file.delete()
+		}
+	}
+	if (rootBuildDir.list()?.length == 0) {
+		rootBuildDir.deleteDir()
+	}
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -66,3 +66,6 @@ profileImageName=craftercms/profile
 gitSshServerImageName=craftercms/git_ssh_server
 gitHttpsServerImageName=craftercms/git_https_server
 logrotateImageName=craftercms/logrotate
+
+craftercmsName=CrafterCMS
+craftercmsUrl=https://craftercms.org/

--- a/gradle/java-library.gradle
+++ b/gradle/java-library.gradle
@@ -34,6 +34,10 @@ plugins.withType(JavaPlugin).configureEach {
 
 	tasks.withType(Javadoc).configureEach {
 		options.addStringOption('Xdoclint:syntax', '-quiet')
+		def year = java.time.Year.now().value
+		options.bottom = "Copyright &copy; ${year} <a href='${craftercmsUrl}'>${craftercmsName}</a>. All rights reserved."
+		options.author = true
+		options.version = true
 	}
 
 	tasks.withType(Test).configureEach {

--- a/gradle/java-library.gradle
+++ b/gradle/java-library.gradle
@@ -38,6 +38,9 @@ plugins.withType(JavaPlugin).configureEach {
 		options.bottom = "Copyright &copy; ${year} <a href='${craftercmsUrl}'>${craftercmsName}</a>. All rights reserved."
 		options.author = true
 		options.version = true
+		title = "${project.crafterManifestTitle} ${craftercmsVersion} API"
+		options.windowTitle = title
+		options.docTitle = title
 	}
 
 	tasks.withType(Test).configureEach {

--- a/gradle/javadoc.gradle
+++ b/gradle/javadoc.gradle
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2007-2026 Crafter Software Corporation. All Rights Reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as published by
+ * the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * Aggregated Javadoc for every Java module, generated as a single site at build/docs/javadoc.
+ *
+ *   ./gradlew aggregateJavadoc
+ *
+ * Per-module javadoc tasks and javadoc jars (see gradle/java-library.gradle) are unaffected.
+ */
+
+ext.aggregateJavadocDirName = 'docs/javadoc'
+
+tasks.register('aggregateJavadoc', Javadoc) {
+	group = 'documentation'
+	description = 'Generates a single Javadoc site for all Java modules'
+
+	destinationDir = layout.buildDirectory.dir(aggregateJavadocDirName).get().asFile
+
+	def docTitle = "${craftercmsName} ${craftercmsVersion} API"
+	title = docTitle
+	options.docTitle = docTitle
+	options.windowTitle = docTitle
+	options.author = true
+	options.version = true
+	options.encoding = 'UTF-8'
+	options.charSet = 'UTF-8'
+	options.docEncoding = 'UTF-8'
+	options.addStringOption('Xdoclint:syntax', '-quiet')
+	def year = java.time.Year.now().value
+	options.bottom = "Copyright &copy; ${year} <a href='${craftercmsUrl}'>${craftercmsName}</a>. All rights reserved."
+	// Modules such as studio do not produce error-free javadoc yet, so a single bad comment
+	// must not fail the whole aggregated site
+	failOnError = false
+}
+
+gradle.projectsEvaluated {
+	def javaProjects = subprojects.findAll { it.plugins.hasPlugin(JavaPlugin) }
+
+	tasks.named('aggregateJavadoc', Javadoc) {
+		source javaProjects.collect { it.sourceSets.main.allJava }
+		classpath = files(javaProjects.collect { it.sourceSets.main.compileClasspath })
+	}
+}


### PR DESCRIPTION
Javadoc related gradle tasks and configs
https://github.com/craftersoftware/craftercms-e/issues/1316

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a unified API documentation site covering Java components.
  * Improved generated documentation with consistent project branding, version details, author information, copyright text, and website metadata.
  * Documentation generation now tolerates non-critical Javadoc warnings, helping builds complete successfully.
* **Build Improvements**
  * Refined build cleanup behavior to preserve generated documentation while removing other temporary build contents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->