### PR TITLE
Allow to override version for javadoc

### DIFF
--- a/gradle/javadoc.gradle
+++ b/gradle/javadoc.gradle
@@ -30,7 +30,8 @@ tasks.register('aggregateJavadoc', Javadoc) {
 
 	destinationDir = layout.buildDirectory.dir(aggregateJavadocDirName).get().asFile
 
-	def docTitle = "${craftercmsName} ${craftercmsVersion} API"
+	def javadocVersion = findProperty('javadoc.version') ?: craftercmsVersion
+	def docTitle = "${craftercmsName} ${javadocVersion} API"
 	title = docTitle
 	options.docTitle = docTitle
 	options.windowTitle = docTitle


### PR DESCRIPTION
Allow to override version for javadoc
https://github.com/craftersoftware/craftercms-e/issues/1316

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the aggregated Javadoc title to display the configured documentation version, with a fallback to the project version when no dedicated version is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->