### PR TITLE
[8868] The Create Content dialog from Pages-Components Item Selector is missing a link in the helper icon

### DIFF
--- a/studio-ui/ui/app/src/components/FormsEngine/controls/NodeSelector.tsx
+++ b/studio-ui/ui/app/src/components/FormsEngine/controls/NodeSelector.tsx
@@ -1020,7 +1020,14 @@ function CreateDataSourcePicker(props: {
 						<FormLabel id="creationStrategyLabel">
 							<FormattedMessage defaultMessage="Creation Strategy" />
 						</FormLabel>
-						<IconButton size="small" sx={{ ml: 1 }} color="primary" component="a" href="/studio" target="_blank">
+						<IconButton
+							size="small"
+							sx={{ ml: 1 }}
+							color="primary"
+							component="a"
+							href="https://craftercms.com/docs/current/by-role/developer/common/content-modeling/content-modeling.html#shared-components-vs-embedded-components"
+							target="_blank"
+						>
 							<HelpOutline fontSize="inherit" />
 						</IconButton>
 					</Box>


### PR DESCRIPTION
https://github.com/craftersoftware/craftercms/issues/8868

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the creation-strategy help link to point to the relevant Crafter CMS documentation.
  * The documentation continues to open in a new browser tab.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->