### PR TITLE
Add missing scripts from deployer image. Remove unnecessary mariadb4j jar file

### DIFF
--- a/craftercms/resources/env/delivery/bin/init-site.groovy
+++ b/craftercms/resources/env/delivery/bin/init-site.groovy
@@ -19,7 +19,7 @@
     @Grab(group='org.apache.commons', module='commons-lang3', version='3.20.0'),
     @Grab(group='org.apache.commons', module='commons-collections4', version='4.5.0'),
     @Grab(group='commons-io', module='commons-io', version='2.21.0'),
-	@Grab(group='com.squareup.okhttp3', module='okhttp-jvm', version='5.1.0')
+	@Grab(group='com.squareup.okhttp3', module='okhttp-jvm', version='5.3.2')
 ])
 
 import groovy.cli.commons.CliBuilder

--- a/craftercms/resources/env/delivery/bin/remove-site.groovy
+++ b/craftercms/resources/env/delivery/bin/remove-site.groovy
@@ -19,7 +19,7 @@
     @Grab(group='org.apache.commons', module='commons-lang3', version='3.20.0'),
     @Grab(group='org.apache.commons', module='commons-collections4', version='4.5.0'),
     @Grab(group='commons-io', module='commons-io', version='2.21.0'),
-    @Grab(group='com.squareup.okhttp3', module='okhttp-jvm', version='5.1.0')
+    @Grab(group='com.squareup.okhttp3', module='okhttp-jvm', version='5.3.2')
 ])
 
 import groovy.cli.commons.CliBuilder

--- a/docker.gradle
+++ b/docker.gradle
@@ -371,7 +371,7 @@ tasks.register('buildDeliveryTomcat') {
 tasks.register('buildDeployer') {
     group = "Build"
     description = "Builds the Deployer Docker image"
-    dependsOn prepareAuthoringBundle
+    dependsOn prepareAuthoringBundle, prepareDeliveryBundle
 	def injected = project.objects.newInstance(InjectedExecOps)
     def imageBuildDir = "${imagesBuildDir}/deployer"
 
@@ -397,6 +397,15 @@ tasks.register('buildDeployer') {
             exclude "apache-tomcat"
             exclude "opensearch"
             exclude "**/*.pid"
+            exclude 'mariaDB4j-app.jar'
+        }
+        copy {
+            from "${deliveryBundleRoot}/bin/"
+            into "${imageBuildDir}/bin"
+            include '*-site.groovy'
+            include '*-site.sh'
+            include 'grapes/**'
+            duplicatesStrategy = 'include'
         }
 
 		injected.execOps.exec {


### PR DESCRIPTION
Add missing scripts from deployer image. Remove unnecessary mariadb4j jar file
https://github.com/craftersoftware/craftercms/issues/8970
https://github.com/craftersoftware/craftercms/issues/7652

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated deployer image assembly to include required delivery site scripts and bundles.
  - Refined authoring bundle contents by excluding an unnecessary database utility.
  - Improved deployment packaging consistency across authoring and delivery components.
  - Updated delivery site setup and removal tooling to use a newer HTTP client version for improved compatibility and reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->