### PR TITLE
Add missing scripts from deployer image. Remove unnecessary mariadb4j jar file

### DIFF
--- a/docker.gradle
+++ b/docker.gradle
@@ -371,7 +371,7 @@ tasks.register('buildDeliveryTomcat') {
 tasks.register('buildDeployer') {
     group = "Build"
     description = "Builds the Deployer Docker image"
-    dependsOn prepareAuthoringBundle
+    dependsOn prepareAuthoringBundle, prepareDeliveryBundle
 	def injected = project.objects.newInstance(InjectedExecOps)
     def imageBuildDir = "${imagesBuildDir}/deployer"
 
@@ -397,6 +397,15 @@ tasks.register('buildDeployer') {
             exclude "apache-tomcat"
             exclude "opensearch"
             exclude "**/*.pid"
+            exclude 'mariaDB4j-app.jar'
+        }
+        copy {
+            from "${deliveryBundleRoot}/bin/"
+            into "${imageBuildDir}/bin"
+            include '*-site.groovy'
+            include '*-site.sh'
+            include 'grapes/**'
+            duplicatesStrategy = 'include'
         }
 
 		injected.execOps.exec {


### PR DESCRIPTION
Add missing scripts from deployer image. Remove unnecessary mariadb4j jar file
https://github.com/craftersoftware/craftercms/issues/8970

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Build and Deployment**
  * Updated deployment image preparation to include required authoring and delivery bundle assets.
  * Excluded an internal MariaDB application file from the authoring bundle during image staging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->