### PR TITLE
[8880] Harden UI against incorrect tokens and failures in APIs

### DIFF
--- a/studio-ui/ui/app/src/components/CrafterCMSNextBridge/CrafterCMSNextBridge.tsx
+++ b/studio-ui/ui/app/src/components/CrafterCMSNextBridge/CrafterCMSNextBridge.tsx
@@ -85,7 +85,7 @@ export function CrafterCMSNextBridge(
 		setRequestForgeryToken();
 		getStore().subscribe({
 			next: (store) => setStore(store),
-			error: ({ message }) => setStoreError(message)
+			error: (error) => setStoreError(typeof error === 'string' ? error : error.message)
 		});
 	}, []);
 

--- a/studio-ui/ui/app/src/components/CrafterCMSNextBridge/CrafterCMSNextBridge.tsx
+++ b/studio-ui/ui/app/src/components/CrafterCMSNextBridge/CrafterCMSNextBridge.tsx
@@ -14,7 +14,16 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { ElementType, Fragment, lazy, PropsWithChildren, ReactNode, Suspense, useLayoutEffect, useState } from 'react';
+import React, {
+	ElementType,
+	Fragment,
+	lazy,
+	PropsWithChildren,
+	ReactNode,
+	Suspense,
+	useLayoutEffect,
+	useState
+} from 'react';
 import { ThemeOptions } from '@mui/material/styles';
 import { setRequestForgeryToken } from '../../utils/auth';
 import { CrafterCMSStore, getStore } from '../../state/store';
@@ -76,7 +85,7 @@ export function CrafterCMSNextBridge(
 		setRequestForgeryToken();
 		getStore().subscribe({
 			next: (store) => setStore(store),
-			error: (message) => setStoreError(message)
+			error: ({ message }) => setStoreError(message)
 		});
 	}, []);
 

--- a/studio-ui/ui/app/src/components/SiteManagement/SiteManagement.tsx
+++ b/studio-ui/ui/app/src/components/SiteManagement/SiteManagement.tsx
@@ -60,6 +60,7 @@ import { previewSwitch } from '../../services/security';
 import { EmptyState } from '../EmptyState';
 import { popDialog, pushDialog } from '../../state/actions/dialogStack';
 import { nanoid } from 'nanoid';
+import { ErrorState } from '../ErrorState';
 
 const translations = defineMessages({
 	siteDeleted: {
@@ -83,7 +84,7 @@ export function SiteManagement() {
 	const [currentView, setCurrentView] = useState<'grid' | 'list'>(
 		getStoredGlobalMenuSiteViewPreference(user.username) ?? 'grid'
 	);
-	const { byId: sitesById, isFetching, active } = useSitesBranch();
+	const { byId: sitesById, isFetching, active, error } = useSitesBranch();
 	const sitesList = sitesById ? Object.values(sitesById) : null;
 	const [selectedSiteStatus, setSelectedSiteStatus] = useState<PublishingStatus>(null);
 	const [permissionsLookup, setPermissionsLookup] = useState<LookupTable<boolean>>(immutableEmptyObject);
@@ -227,7 +228,14 @@ export function SiteManagement() {
 				}
 			/>
 			<ErrorBoundary>
-				{isFetching ? (
+				{error ? (
+					<ErrorState
+						title={
+							<FormattedMessage defaultMessage="An error occurred while loading projects. Please contact your administrator." />
+						}
+						sxs={{ root: { mt: 4 } }}
+					/>
+				) : isFetching ? (
 					<SkeletonSitesGrid numOfItems={3} currentView={currentView} />
 				) : sitesList ? (
 					sitesList.length > 0 ? (

--- a/studio-ui/ui/app/src/models/GlobalState.ts
+++ b/studio-ui/ui/app/src/models/GlobalState.ts
@@ -146,6 +146,7 @@ export interface GlobalState {
 		active: string;
 		isFetching: boolean;
 		byId: LookupTable<Site>;
+		error: ApiResponse;
 	};
 	content: {
 		quickCreate: {

--- a/studio-ui/ui/app/src/state/actions/sites.ts
+++ b/studio-ui/ui/app/src/state/actions/sites.ts
@@ -15,7 +15,7 @@
  */
 
 import { createAction } from '@reduxjs/toolkit';
-import { Site, StandardAction } from '../../models';
+import { ApiResponse, Site, StandardAction } from '../../models';
 
 export function changeSite(nextSite: string, nextUrl: string = '/'): StandardAction {
 	return {
@@ -31,5 +31,5 @@ changeSite.type = 'CHANGE_SITE';
 
 export const fetchSites = /*#__PURE__*/ createAction('FETCH_SITES');
 export const fetchSitesComplete = /*#__PURE__*/ createAction<Site[]>('FETCH_SITES_COMPLETE');
-export const fetchSitesFailed = /*#__PURE__*/ createAction('FETCH_SITES_FAILED');
+export const fetchSitesFailed = /*#__PURE__*/ createAction<{ error: ApiResponse }>('FETCH_SITES_FAILED');
 export const popSite = /*#__PURE__*/ createAction<{ siteId: string; isActive: boolean }>('POP_SITE');

--- a/studio-ui/ui/app/src/state/epics/sites.ts
+++ b/studio-ui/ui/app/src/state/epics/sites.ts
@@ -18,7 +18,7 @@ import { ofType, StateObservable } from 'redux-observable';
 import { map, switchMap, tap, withLatestFrom } from 'rxjs/operators';
 import { setSiteCookie } from '../../utils/auth';
 import { fetchAll } from '../../services/sites';
-import { catchAjaxError } from '../../utils/ajax';
+import { catchAjaxError, extractErrorPayload } from '../../utils/ajax';
 import {
 	changeSite,
 	changeSiteComplete,
@@ -72,7 +72,12 @@ export default [
 	(action$) =>
 		action$.pipe(
 			ofType(fetchSitesAction.type),
-			switchMap(() => fetchAll().pipe(map(fetchSitesComplete), catchAjaxError(fetchSitesFailed)))
+			switchMap(() =>
+				fetchAll().pipe(
+					map(fetchSitesComplete),
+					catchAjaxError((error) => fetchSitesFailed({ error: extractErrorPayload(error) }))
+				)
+			)
 		)
 	// endregion
 ] as CrafterCMSEpic[];

--- a/studio-ui/ui/app/src/state/reducers/sites.ts
+++ b/studio-ui/ui/app/src/state/reducers/sites.ts
@@ -23,14 +23,15 @@ import { changeSiteComplete, fetchSites, fetchSitesComplete, fetchSitesFailed, p
 export const initialState: GlobalState['sites'] = {
 	byId: {},
 	active: null,
-	isFetching: false
+	isFetching: false,
+	error: null
 };
 
 const reducer = createReducer<GlobalState['sites']>(initialState, (builder) => {
 	builder
 		.addCase(storeInitialized, (state, { payload }) => ({
 			...state,
-			byId: createLookupTable(payload.sites),
+			byId: payload.sites ? createLookupTable(payload.sites) : {},
 			active: payload.activeSiteId
 		}))
 		.addCase(changeSiteComplete, (state, { payload }) =>
@@ -48,11 +49,13 @@ const reducer = createReducer<GlobalState['sites']>(initialState, (builder) => {
 		.addCase(fetchSitesComplete, (state, { payload }) => ({
 			...state,
 			byId: createLookupTable(payload),
-			isFetching: false
+			isFetching: false,
+			error: null
 		}))
 		.addCase(fetchSitesFailed, (state, action) => ({
 			...state,
-			isFetching: false
+			isFetching: false,
+			error: action.payload?.error
 		}))
 		.addCase(popSite, (state, { payload }) => {
 			if (payload?.siteId) {

--- a/studio-ui/ui/app/src/state/reducers/sites.ts
+++ b/studio-ui/ui/app/src/state/reducers/sites.ts
@@ -44,7 +44,8 @@ const reducer = createReducer<GlobalState['sites']>(initialState, (builder) => {
 		)
 		.addCase(fetchSites, (state, action) => ({
 			...state,
-			isFetching: true
+			isFetching: true,
+			error: null
 		}))
 		.addCase(fetchSitesComplete, (state, { payload }) => ({
 			...state,

--- a/studio-ui/ui/app/src/state/store.ts
+++ b/studio-ui/ui/app/src/state/store.ts
@@ -52,6 +52,8 @@ import { fetchActiveEnvironment } from '../services/environment';
 import { batchActions, dispatchDOMEvent } from './actions/misc';
 import { closeSingleFileUploadDialog } from './actions/dialogs';
 import { pushDialog, pushNonDialog } from './actions/dialogStack';
+import { fetchSitesFailed } from './actions/sites';
+import { extractErrorPayload } from '../utils/ajax';
 
 export type EpicMiddlewareDependencies = {
 	getIntl: () => IntlShape;
@@ -78,7 +80,7 @@ export function getStore(): Observable<CrafterCMSStore> {
 			switchMap(({ worker, ...auth }) =>
 				of(createStoreSync({ dependencies: { worker } })).pipe(
 					switchMap((store) =>
-						fetchStateInitialization().pipe(
+						fetchStateInitialization(store).pipe(
 							tap((requirements) => {
 								worker.port.onmessage = (e) => {
 									if (e.data?.type) {
@@ -206,7 +208,7 @@ export function createStoreSync(args: { preloadedState?: any; dependencies?: any
 	return store;
 }
 
-export function fetchStateInitialization(): Observable<{
+export function fetchStateInitialization(store: CrafterCMSStore): Observable<{
 	user: User;
 	sites: Site[];
 	properties: LookupTable<any>;
@@ -216,7 +218,12 @@ export function fetchStateInitialization(): Observable<{
 	const siteCookieValue = getSiteCookie();
 	return forkJoin({
 		user: me(),
-		sites: fetchAll(),
+		sites: fetchAll().pipe(
+			catchError((error) => {
+				store.dispatch(fetchSitesFailed({ error: extractErrorPayload(error) }));
+				return of(null);
+			})
+		),
 		properties: fetchGlobalProperties(),
 		activeSiteId:
 			// A site cookie may be set but the site may have been deleted.
@@ -227,7 +234,13 @@ export function fetchStateInitialization(): Observable<{
 						tap((siteExists) => !siteExists && removeSiteCookie()),
 						map((siteExists) => (siteExists ? siteCookieValue : null)),
 						// If the exists check fails (e.g. network/API error), don't break store init
-						catchError(() => of(null))
+						catchError(() => {
+							// If error, go to global menu page
+							if (window.location.pathname !== '/studio') {
+								window.location.href = '/studio';
+							}
+							return of(null);
+						})
 					)
 				: of(null),
 		activeEnvironment: fetchActiveEnvironment()

--- a/studio-ui/ui/app/src/utils/ajax.ts
+++ b/studio-ui/ui/app/src/utils/ajax.ts
@@ -186,12 +186,11 @@ export const errorSelectorApi1: <T, O extends ObservableInput<any>>(err: any, ca
 };
 
 export const extractErrorPayload = (error: AjaxError): ApiResponse => {
-	// Same fallback as catchAjaxError so fetchSitesFailed (and similar) always get an ApiResponse.
-	return (
-		error?.response?.response ??
-		error?.response ?? {
-			code: error?.status,
-			message: 'An unknown error has occurred.'
-		}
-	);
+	const response = error?.response?.response ?? error?.response;
+	return typeof response === 'string'
+		? { code: error?.status, message: response }
+		: (response ?? {
+				code: error?.status,
+				message: 'An unknown error has occurred.'
+			});
 };

--- a/studio-ui/ui/app/src/utils/ajax.ts
+++ b/studio-ui/ui/app/src/utils/ajax.ts
@@ -185,6 +185,13 @@ export const errorSelectorApi1: <T, O extends ObservableInput<any>>(err: any, ca
 	throw error;
 };
 
-export const extractErrorPayload = (error: AjaxError): ApiResponse | AjaxError => {
-	return error?.response?.response ?? error?.response ?? error;
+export const extractErrorPayload = (error: AjaxError): ApiResponse => {
+	// Same fallback as catchAjaxError so fetchSitesFailed (and similar) always get an ApiResponse.
+	return (
+		error?.response?.response ??
+		error?.response ?? {
+			code: error?.status,
+			message: 'An unknown error has occurred.'
+		}
+	);
 };


### PR DESCRIPTION
https://github.com/craftersoftware/craftercms/issues/8880

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Site-loading failures now display a clear error state instead of a loading skeleton.
  * Error messages are surfaced more consistently for store and site requests, including incomplete or string-based error details.
  * Site data initializes safely when initial state information is unavailable.
  * Users are redirected to the Studio when active-site validation fails outside the Studio area.
  * Site-loading errors are cleared when a new request starts or completes successfully.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->