### PR TITLE
[7359] Add support for alternate Freemarker suffixes besides .ftl (.ftlh .ftlx)

### DIFF
--- a/studio-ui/ui/app/src/components/CreateFileDialog/CreateFileDialogContainer.tsx
+++ b/studio-ui/ui/app/src/components/CreateFileDialog/CreateFileDialogContainer.tsx
@@ -85,13 +85,13 @@ export function CreateFileDialogContainer(props: CreateFileContainerProps) {
 	const onSubmit = () => {
 		updateSubmittingOrHasPendingChanges({ isSubmitting: true });
 		if (name) {
+			const fileName = getFileName(name);
 			validateActionPolicy(site, {
 				type: 'CREATE',
-				target: `${path}/${name}`
+				target: `${path}/${fileName}`
 			}).subscribe({
 				next: ({ allowed, modifiedValue, message }) => {
 					if (allowed) {
-						const fileName = getFileName(name);
 						const pathToCheckExists = modifiedValue ?? `${path}/${fileName}`;
 						setItemExists(false);
 						checkPathExistence(site, pathToCheckExists).subscribe({
@@ -112,7 +112,7 @@ export function CreateFileDialogContainer(props: CreateFileContainerProps) {
 					} else {
 						setConfirm({
 							error: true,
-							body: formatMessage(translations.policyError, { fileName: name, detail: message })
+							body: formatMessage(translations.policyError, { fileName, detail: message })
 						});
 						updateSubmittingOrHasPendingChanges({ isSubmitting: false });
 					}
@@ -123,8 +123,7 @@ export function CreateFileDialogContainer(props: CreateFileContainerProps) {
 	};
 
 	const onConfirm = () => {
-		const fileName = getFileName(name);
-		onCreateFile(site, path, fileName);
+		onCreateFile(site, path, getFileName(name));
 	};
 
 	const onConfirmCancel = () => {

--- a/studio-ui/ui/app/src/components/CreateFileDialog/CreateFileDialogContainer.tsx
+++ b/studio-ui/ui/app/src/components/CreateFileDialog/CreateFileDialogContainer.tsx
@@ -22,11 +22,15 @@ import { checkPathExistence, createFile } from '../../services/content';
 import { validateActionPolicy } from '../../services/sites';
 import DialogBody from '../DialogBody/DialogBody';
 import TextField from '@mui/material/TextField';
+import Box from '@mui/material/Box';
+import FormControl from '@mui/material/FormControl';
+import Select, { SelectChangeEvent } from '@mui/material/Select';
+import MenuItem from '@mui/material/MenuItem';
 import DialogFooter from '../DialogFooter/DialogFooter';
 import SecondaryButton from '../SecondaryButton';
 import PrimaryButton from '../PrimaryButton';
 import ConfirmDialog from '../ConfirmDialog';
-import { CreateFileContainerProps } from './utils';
+import { CreateFileContainerProps, DEFAULT_TEMPLATE_EXTENSION, TEMPLATE_EXTENSIONS, TemplateExtension } from './utils';
 import { translations } from './translations';
 import useEnhancedDialogContext from '../EnhancedDialog/useEnhancedDialogContext';
 import useItemsByPath from '../../hooks/useItemsByPath';
@@ -42,12 +46,15 @@ export function CreateFileDialogContainer(props: CreateFileContainerProps) {
 	const { onClose, onCreated, type, path, allowBraces } = props;
 	const { isSubmitting, hasPendingChanges } = useEnhancedDialogContext();
 	const [name, setName] = useState('');
+	const [extension, setExtension] = useState<TemplateExtension>(DEFAULT_TEMPLATE_EXTENSION);
 	const [confirm, setConfirm] = useState(null);
 	const dispatch = useDispatch();
 	const site = useActiveSiteId();
 	const { formatMessage } = useIntl();
 	const itemLookup = useItemsByPath();
-	const computedFilePath = `${path}/${getFileNameWithExtensionForItemType(type, name)}`;
+	const getFileName = (fileName: string) =>
+		getFileNameWithExtensionForItemType(type, fileName, type === 'template' ? extension : undefined);
+	const computedFilePath = `${path}/${getFileName(name)}`;
 	// When calling the validation API, we need to check if the item with the suggested name exists. This is an extra validation for the
 	// fileExists const.
 	const [itemExists, setItemExists] = useState(false);
@@ -64,7 +71,12 @@ export function CreateFileDialogContainer(props: CreateFileContainerProps) {
 		createFile(site, path, fileName).subscribe({
 			next() {
 				updateSubmittingOrHasPendingChanges({ hasPendingChanges: false, isSubmitting: false });
-				onCreated?.({ path, fileName, mode: pickExtensionForItemType(type), openOnSuccess: true });
+				onCreated?.({
+					path,
+					fileName,
+					mode: pickExtensionForItemType(type, fileName, type === 'template' ? 'ftl' : undefined),
+					openOnSuccess: true
+				});
 			},
 			error: onError
 		});
@@ -79,7 +91,7 @@ export function CreateFileDialogContainer(props: CreateFileContainerProps) {
 			}).subscribe({
 				next: ({ allowed, modifiedValue, message }) => {
 					if (allowed) {
-						const fileName = getFileNameWithExtensionForItemType(type, name);
+						const fileName = getFileName(name);
 						const pathToCheckExists = modifiedValue ?? `${path}/${fileName}`;
 						setItemExists(false);
 						checkPathExistence(site, pathToCheckExists).subscribe({
@@ -111,7 +123,7 @@ export function CreateFileDialogContainer(props: CreateFileContainerProps) {
 	};
 
 	const onConfirm = () => {
-		const fileName = getFileNameWithExtensionForItemType(type, name);
+		const fileName = getFileName(name);
 		onCreateFile(site, path, fileName);
 	};
 
@@ -127,6 +139,57 @@ export function CreateFileDialogContainer(props: CreateFileContainerProps) {
 		hasPendingChanges !== newHasPending && updateSubmittingOrHasPendingChanges({ hasPendingChanges: newHasPending });
 	};
 
+	const onExtensionChange = (event: SelectChangeEvent<TemplateExtension>) => {
+		setExtension(event.target.value);
+		setItemExists(false);
+	};
+
+	const fileNameField = (
+		<TextField
+			label={<FormattedMessage id="createFileDialog.fileName" defaultMessage="File Name" />}
+			value={name}
+			fullWidth={type !== 'template'}
+			autoFocus
+			required
+			error={(!name && Boolean(isSubmitting)) || fileExists}
+			placeholder={formatMessage(translations.placeholder)}
+			helperText={
+				fileExists ? (
+					<FormattedMessage
+						id="createFileDialog.fileAlreadyExists"
+						defaultMessage="A file with that name already exists"
+					/>
+				) : !name && isSubmitting ? (
+					<FormattedMessage id="createFileDialog.fileNameRequired" defaultMessage="File name is required." />
+				) : (
+					<FormattedMessage
+						id="createFileDialog.helperText"
+						defaultMessage="Consisting of letters, numbers, dot (.), dash (-) and underscore (_)."
+					/>
+				)
+			}
+			disabled={isSubmitting}
+			margin={type === 'template' ? 'none' : 'normal'}
+			sx={type === 'template' ? { flex: 1 } : undefined}
+			slotProps={{
+				inputLabel: { shrink: true }
+			}}
+			onChange={(event) => onInputChanges(applyAssetNameRules(event.target.value, { allowBraces }))}
+		/>
+	);
+
+	const extensionField = (
+		<FormControl variant="outlined" sx={{ minWidth: 110, flexShrink: 0 }} disabled={isSubmitting}>
+			<Select id="createFileDialogExtension" value={extension} onChange={onExtensionChange}>
+				{TEMPLATE_EXTENSIONS.map((templateExtension) => (
+					<MenuItem key={templateExtension} value={templateExtension}>
+						{`.${templateExtension}`}
+					</MenuItem>
+				))}
+			</Select>
+		</FormControl>
+	);
+
 	return (
 		<>
 			<DialogBody>
@@ -138,36 +201,14 @@ export function CreateFileDialogContainer(props: CreateFileContainerProps) {
 						}
 					}}
 				>
-					<TextField
-						label={<FormattedMessage id="createFileDialog.fileName" defaultMessage="File Name" />}
-						value={name}
-						fullWidth
-						autoFocus
-						required
-						error={(!name && Boolean(isSubmitting)) || fileExists}
-						placeholder={formatMessage(translations.placeholder)}
-						helperText={
-							fileExists ? (
-								<FormattedMessage
-									id="createFileDialog.fileAlreadyExists"
-									defaultMessage="A file with that name already exists"
-								/>
-							) : !name && isSubmitting ? (
-								<FormattedMessage id="createFileDialog.fileNameRequired" defaultMessage="File name is required." />
-							) : (
-								<FormattedMessage
-									id="createFileDialog.helperText"
-									defaultMessage="Consisting of letters, numbers, dot (.), dash (-) and underscore (_)."
-								/>
-							)
-						}
-						disabled={isSubmitting}
-						margin="normal"
-						slotProps={{
-							inputLabel: { shrink: true }
-						}}
-						onChange={(event) => onInputChanges(applyAssetNameRules(event.target.value, { allowBraces }))}
-					/>
+					{type === 'template' ? (
+						<Box sx={{ display: 'flex', alignItems: 'baseline', gap: 1, mt: 2, mb: 1 }}>
+							{fileNameField}
+							{extensionField}
+						</Box>
+					) : (
+						fileNameField
+					)}
 				</form>
 			</DialogBody>
 			<DialogFooter>

--- a/studio-ui/ui/app/src/components/CreateFileDialog/utils.ts
+++ b/studio-ui/ui/app/src/components/CreateFileDialog/utils.ts
@@ -40,4 +40,4 @@ export const TEMPLATE_EXTENSIONS = ['ftl', 'ftlh', 'ftlx'] as const;
 
 export type TemplateExtension = (typeof TEMPLATE_EXTENSIONS)[number];
 
-export const DEFAULT_TEMPLATE_EXTENSION: TemplateExtension = 'ftl';
+export const DEFAULT_TEMPLATE_EXTENSION: TemplateExtension = 'ftlh';

--- a/studio-ui/ui/app/src/components/CreateFileDialog/utils.ts
+++ b/studio-ui/ui/app/src/components/CreateFileDialog/utils.ts
@@ -35,3 +35,9 @@ export interface CreateFileStateProps extends CreateFileBaseProps, EnhancedDialo
 }
 
 export interface CreateFileContainerProps extends CreateFileBaseProps, Pick<CreateFileProps, 'onCreated' | 'onClose'> {}
+
+export const TEMPLATE_EXTENSIONS = ['ftl', 'ftlh', 'ftlx'] as const;
+
+export type TemplateExtension = (typeof TEMPLATE_EXTENSIONS)[number];
+
+export const DEFAULT_TEMPLATE_EXTENSION: TemplateExtension = 'ftl';

--- a/studio-ui/ui/app/src/components/RenameAssetDialog/RenameAssetDialogContainer.tsx
+++ b/studio-ui/ui/app/src/components/RenameAssetDialog/RenameAssetDialogContainer.tsx
@@ -21,7 +21,7 @@ import { FormattedMessage, useIntl } from 'react-intl';
 import { useDispatch } from 'react-redux';
 import useActiveSiteId from '../../hooks/useActiveSiteId';
 import useItemsByPath from '../../hooks/useItemsByPath';
-import { getFileNameWithExtensionForItemType, getParentPath } from '../../utils/path';
+import { getFileExtension, getFileNameWithExtensionForItemType, getParentPath } from '../../utils/path';
 import { UNDEFINED } from '../../utils/constants';
 import { isBlank } from '../../utils/string';
 import SecondaryButton from '../SecondaryButton';
@@ -53,6 +53,7 @@ export function RenameAssetDialogContainer(props: RenameAssetContainerProps) {
 	const value = item?.label ?? '';
 	const { isSubmitting, hasPendingChanges } = useEnhancedDialogContext();
 	const [name, setName] = useState(value);
+	const initialExtension = getFileExtension(value);
 	const dispatch = useDispatch();
 	const itemLookupTable = useItemsByPath();
 	const newAssetName = type !== 'asset' ? getFileNameWithExtensionForItemType(type, name) : name;
@@ -75,7 +76,7 @@ export function RenameAssetDialogContainer(props: RenameAssetContainerProps) {
 	};
 
 	const onRenameAsset = (siteId: string, path: string, name: string) => {
-		const fileName = type !== 'asset' ? getFileNameWithExtensionForItemType(type, name) : name;
+		const fileName = type !== 'asset' ? getFileNameWithExtensionForItemType(type, name, initialExtension) : name;
 		renameContent(siteId, path, fileName).subscribe({
 			next() {
 				updateSubmittingOrHasPendingChanges({ isSubmitting: false, hasPendingChanges: false });

--- a/studio-ui/ui/app/src/components/RenameAssetDialog/RenameAssetDialogContainer.tsx
+++ b/studio-ui/ui/app/src/components/RenameAssetDialog/RenameAssetDialogContainer.tsx
@@ -56,7 +56,7 @@ export function RenameAssetDialogContainer(props: RenameAssetContainerProps) {
 	const initialExtension = getFileExtension(value);
 	const dispatch = useDispatch();
 	const itemLookupTable = useItemsByPath();
-	const newAssetName = type !== 'asset' ? getFileNameWithExtensionForItemType(type, name) : name;
+	const newAssetName = type !== 'asset' ? getFileNameWithExtensionForItemType(type, name, initialExtension) : name;
 	const newAssetPath = `${getParentPath(path)}/${newAssetName}`;
 	const assetExists = newAssetName !== value && itemLookupTable[newAssetPath] !== UNDEFINED;
 	const isValid = !isBlank(name) && !assetExists && name !== value;

--- a/studio-ui/ui/app/src/utils/path.ts
+++ b/studio-ui/ui/app/src/utils/path.ts
@@ -349,18 +349,23 @@ export function processPathMacros(dependencies: {
 	return processedPath;
 }
 
-export const pickExtensionForItemType = (systemType: string, name?: string) => {
+export const pickExtensionForItemType = (systemType: string, name?: string, extension?: string) => {
 	if (systemType === 'asset') {
 		return getFileExtension(name);
+	} else if (systemType === 'controller') {
+		return 'groovy';
+	} else if (extension) {
+		return extension.replace(/^\./, '');
 	} else {
-		return systemType === 'controller' ? `groovy` : `ftl`;
+		return 'ftl';
 	}
 };
 
-export const getFileNameWithExtensionForItemType = (type: string, name: string) =>
-	`${name}.${pickExtensionForItemType(type)}`
-		.replace(/(\.groovy)(\.groovy)|(\.ftl)(\.ftl)/g, '$1$3')
-		.replace(/\.{2,}/g, '.');
+export const getFileNameWithExtensionForItemType = (type: string, name: string, extension?: string) => {
+	const pickedExtension = pickExtensionForItemType(type, name, extension);
+	const normalizedName = name.replace(new RegExp(`\\.${pickedExtension}$`), '');
+	return `${normalizedName}.${pickedExtension}`.replace(/\.{2,}/g, '.');
+};
 
 /**
  * Determines if the given path corresponds to a page path.


### PR DESCRIPTION
https://github.com/craftersoftware/craftercms/issues/7359

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Template creation supports selecting a file extension, with `.ftlh` used by default.
  * Generated filenames reflect the selected template extension and avoid duplicate suffixes.
  * Template filename and extension controls are arranged appropriately and disabled during creation.
* **Bug Fixes**
  * Renaming non-asset files now preserves their existing extension during validation and renaming.
  * Existing behavior for non-template files, assets, and controller files remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->