### PR TITLE
mime.types for alternate freemarker suffixes

### DIFF
--- a/deployer/src/main/resources/META-INF/mime.types
+++ b/deployer/src/main/resources/META-INF/mime.types
@@ -1487,7 +1487,7 @@ text/vnd.wap.wml				wml
 text/vnd.wap.wmlscript				wmls
 text/x-asm					s asm
 text/x-c					c cc cxx cpp h hh dic
-text/x-freemarker           ftl
+text/x-freemarker           ftl ftlx ftlh
 text/x-fortran					f for f77 f90
 text/x-groovy               groovy
 text/x-handlebars-template        hbs

--- a/studio/src/main/resources/META-INF/mime.types
+++ b/studio/src/main/resources/META-INF/mime.types
@@ -1749,7 +1749,7 @@ text/vnd.wap.wml				wml
 text/vnd.wap.wmlscript				wmls
 text/x-asm					s asm
 text/x-c					c cc cxx cpp h hh dic
-text/x-freemarker           ftl
+text/x-freemarker           ftl ftlx ftlh
 text/x-fortran					f for f77 f90
 text/x-groovy               groovy
 text/x-handlebars-template        hbs

--- a/studio/src/main/resources/crafter/studio/database/upgrade/5.0.x/5.0.0.25-to-5.0.0.26.sql
+++ b/studio/src/main/resources/crafter/studio/database/upgrade/5.0.x/5.0.0.25-to-5.0.0.26.sql
@@ -15,7 +15,7 @@
  */
 
 UPDATE item
-SET system_type = 'renderingTemplate'
+SET system_type = 'renderingTemplate', mime_type = 'text/x-freemarker'
 WHERE system_type <> 'folder'
 AND path like '/templates/%'
 AND (path like '%.ftlx' OR path like '%.ftlh') ;


### PR DESCRIPTION
mime.types for alternate freemarker suffixes
https://github.com/craftersoftware/craftercms/issues/8737

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for `.ftlx` and `.ftlh` FreeMarker template files alongside `.ftl` files.
  * These extensions are now recognized consistently across deployment and studio tooling.

* **Bug Fixes**
  * Database upgrades now correctly assign the FreeMarker MIME type to rendering templates, improving template identification after migration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->