### PR TITLE
Replace version in ee docker compose files

### DIFF
--- a/release.gradle
+++ b/release.gradle
@@ -71,10 +71,15 @@ ext.applyReleaseVersions = { String releaseVersion, String gitBranchName ->
 	def composeFiles = fileTree(dir: "${projectDir}/docker-compose", include: '**/docker-compose*.yml')
 	composeFiles.each { composeFile ->
 		updateFileIfChanged(composeFile) { text ->
-			text.replaceAll(
+			def result = text.replaceAll(
 				/image: ([^:\s]+):([^:\s]+) # craftercms version flag/,
 				"image: \$1:${releaseVersion} # craftercms version flag"
 			)
+			result = result.replaceAll(
+				/image: ([^:\s]+):([^:\s]+) # craftercms enterprise version flag/,
+				"image: \$1:${releaseVersion}E # craftercms enterprise version flag"
+			)
+			result
 		}
 	}
 }


### PR DESCRIPTION
Replace version in ee docker compose files
https://github.com/craftersoftware/craftercms-e/issues/1320

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Docker Compose version updates now correctly apply to both community and enterprise image tags.
  * Enterprise image tags retain their enterprise marker while receiving the updated release version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->