### PR TITLE
[8874] Long filenames/internal names expand card height and break grid row alignment in Select an Item browse dialog

### DIFF
--- a/studio-ui/ui/app/src/components/MediaCard/MediaCard.tsx
+++ b/studio-ui/ui/app/src/components/MediaCard/MediaCard.tsx
@@ -146,23 +146,37 @@ function MediaCard(props: MediaCardProps) {
 				title={name}
 				subheader={showPath ? item.path : null}
 				action={action}
-				titleTypographyProps={{
-					variant: 'subtitle2',
-					component: 'h2',
-					sx: {
-						...cardTitleStyles
+				slotProps={{
+					content: {
+						sx: {
+							flexGrow: 1,
+							minWidth: 0
+						}
 					},
-					title: item.name
-				}}
-				subheaderTypographyProps={{
-					variant: 'subtitle2',
-					component: 'div',
-					sx: {
-						...cardSubtitleStyles,
-						WebkitLineClamp: 1
+					title: {
+						variant: 'subtitle2',
+						component: 'h2',
+						sx: {
+							whiteSpace: 'nowrap',
+							overflow: 'hidden',
+							textOverflow: 'ellipsis',
+							width: '100%',
+							...cardTitleStyles
+						},
+						title: item.name
 					},
-					color: 'textSecondary',
-					title: item.path
+					subheader: {
+						variant: 'subtitle2',
+						component: 'div',
+						sx: {
+							...cardSubtitleStyles,
+							'&&': {
+								display: '-webkit-box'
+							},
+							WebkitLineClamp: 2
+						},
+						title: item.path
+					}
 				}}
 			/>
 			{viewMode !== 'compact' && (


### PR DESCRIPTION
https://github.com/craftersoftware/craftercms/issues/8874

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved media card headers with clearer title truncation and two-line subheader display.
  * Preserved full path visibility through the subheader tooltip.
  * Updated header styling for more consistent sizing and customization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->