### PR TITLE
SiteItemService return SiteItem only when matching allowed regexes

### DIFF
--- a/engine/src/main/java/org/craftercms/engine/service/SiteItemService.java
+++ b/engine/src/main/java/org/craftercms/engine/service/SiteItemService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2007-2022 Crafter Software Corporation. All Rights Reserved.
+ * Copyright (C) 2007-2026 Crafter Software Corporation. All Rights Reserved.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as published by
@@ -131,4 +131,11 @@ public interface SiteItemService {
     SiteItem getSiteTree(String url, int depth, String includeByNameRegex, String excludeByNameRegex,
                          Map<String, String> nodeXPathAndExpectedValuePairs);
 
+    /**
+     * Checks if the item exists at the given path.
+     *
+     * @param path the path to check
+     * @return true if the item exists, false otherwise
+     */
+    boolean exists(String path);
 }

--- a/engine/src/main/java/org/craftercms/engine/service/impl/SiteItemServiceImpl.java
+++ b/engine/src/main/java/org/craftercms/engine/service/impl/SiteItemServiceImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2007-2022 Crafter Software Corporation. All Rights Reserved.
+ * Copyright (C) 2007-2026 Crafter Software Corporation. All Rights Reserved.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as published by
@@ -14,6 +14,14 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 package org.craftercms.engine.service.impl;
+
+import static org.craftercms.engine.util.LocaleUtils.resolveLocalePath;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 import org.apache.commons.collections.MapUtils;
 import org.apache.commons.collections4.CollectionUtils;
@@ -39,14 +47,6 @@ import org.craftercms.engine.service.filter.ExcludeByNameItemFilter;
 import org.craftercms.engine.service.filter.ExpectedNodeValueItemFilter;
 import org.craftercms.engine.service.filter.IncludeByNameItemFilter;
 import org.dom4j.Element;
-
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
-import static org.craftercms.engine.util.LocaleUtils.resolveLocalePath;
 
 /**
  * Default implementation of {@link SiteItemService}.
@@ -231,6 +231,11 @@ public class SiteItemServiceImpl implements SiteItemService {
         } else {
             return null;
         }
+    }
+
+    @Override
+    public boolean exists(String path) {
+        return storeService.exists(getSiteContext().getContext(), path);
     }
 
     protected SiteContext getSiteContext() {

--- a/engine/src/main/java/org/craftercms/engine/util/config/profiles/ConfigurationProviderImpl.java
+++ b/engine/src/main/java/org/craftercms/engine/util/config/profiles/ConfigurationProviderImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2007-2024 Crafter Software Corporation. All Rights Reserved.
+ * Copyright (C) 2007-2026 Crafter Software Corporation. All Rights Reserved.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as published by
@@ -41,7 +41,7 @@ public class ConfigurationProviderImpl implements ConfigurationProvider {
 
     @Override
     public boolean configExists(String path) {
-        return siteItemService.getSiteItem(path) != null;
+        return siteItemService.exists(path);
     }
 
     @Override

--- a/engine/src/main/java/org/craftercms/engine/util/predicates/ExpiredItemPredicate.java
+++ b/engine/src/main/java/org/craftercms/engine/util/predicates/ExpiredItemPredicate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2007-2022 Crafter Software Corporation. All Rights Reserved.
+ * Copyright (C) 2007-2026 Crafter Software Corporation. All Rights Reserved.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as published by

--- a/engine/src/main/java/org/craftercms/engine/util/predicates/IncludeByUrlPredicate.java
+++ b/engine/src/main/java/org/craftercms/engine/util/predicates/IncludeByUrlPredicate.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2007-2026 Crafter Software Corporation. All Rights Reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as published by
+ * the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.craftercms.engine.util.predicates;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import org.apache.commons.collections4.Predicate;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.craftercms.core.service.Item;
+
+/**
+ * Predicate used to check if an item is included by its url.
+ *
+ **/
+public class IncludeByUrlPredicate implements Predicate<Item> {
+
+	private static final Log logger = LogFactory.getLog(IncludeByUrlPredicate.class);
+
+	protected List<Pattern> includePatterns;
+
+	public IncludeByUrlPredicate(String[] includeRegexes) {
+		this.includePatterns = Arrays.stream(includeRegexes).map(Pattern::compile).collect(Collectors.toList());
+	}
+
+	@Override
+	public boolean evaluate(Item item) {
+		return includePatterns.stream().anyMatch(p -> p.matcher(item.getUrl()).matches());
+	}
+
+}

--- a/engine/src/main/resources/crafter/engine/mode/preview/services-context.xml
+++ b/engine/src/main/resources/crafter/engine/mode/preview/services-context.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (C) 2007-2025 Crafter Software Corporation. All Rights Reserved.
+  ~ Copyright (C) 2007-2026 Crafter Software Corporation. All Rights Reserved.
   ~
   ~ This program is free software: you can redistribute it and/or modify
   ~ it under the terms of the GNU General Public License version 3 as published by
@@ -101,7 +101,11 @@
     <!--									-->
     <!-- ////////////////////////////////// -->
 
-    <util:list id="crafter.defaultItemPredicates"/>
+    
+    <util:list id="crafter.defaultItemPredicates">
+        <!-- Allow items matching the include regexes only -->
+        <ref bean="crafter.includeByUrlItemPredicate"/>
+    </util:list>
 
     <bean id="crafter.cacheTemplate" class="org.craftercms.core.util.cache.impl.NoopCacheTemplate">
         <constructor-arg name="cacheService" ref="crafter.cacheService" />

--- a/engine/src/main/resources/crafter/engine/server-config.properties
+++ b/engine/src/main/resources/crafter/engine/server-config.properties
@@ -31,6 +31,8 @@ crafter.engine.site.default.cache.maxAllowedItems=250000
 # (preview or multi-tenant modes). The value should be a String Resource URL, so it can start with classpath, file,
 # http, ftp, etc. When no prefix is present it means the folder is inside the webapp folder.
 crafter.engine.site.default.rootFolder.path=default-site
+# List of regular expressions for the paths that are allowed to be used as descriptor paths (the SiteItemService will only return items from these paths)
+crafter.engine.site.default.descriptors.allowed.paths=/site/.*
 # The path where page descriptors can be found, relative to the root folder
 crafter.engine.site.default.descriptors.pages.path=/site/website
 # The path where static assets can be found, relative to the root folder

--- a/engine/src/main/resources/crafter/engine/services/main-services-context.xml
+++ b/engine/src/main/resources/crafter/engine/services/main-services-context.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  * Copyright (C) 2007-2025 Crafter Software Corporation. All Rights Reserved.
+  * Copyright (C) 2007-2026 Crafter Software Corporation. All Rights Reserved.
   *
   * This program is free software: you can redistribute it and/or modify
   * it under the terms of the GNU General Public License version 3 as published by
@@ -298,6 +298,10 @@
         <constructor-arg name="dateConverter" ref="crafter.stringToUtcDateConverter"/>
     </bean>
 
+    <bean id="crafter.includeByUrlItemPredicate" class="org.craftercms.engine.util.predicates.IncludeByUrlPredicate">
+        <constructor-arg name="includeRegexes" value="${crafter.engine.site.default.descriptors.allowed.paths}"/>
+    </bean>
+
     <bean id="crafter.excludeLevelDescriptorItemFilter" class="org.craftercms.engine.service.filter.ExcludeByNameItemFilter">
         <constructor-arg name="excludeRegex"
                          value="${crafter.core.merger.strategy.inheritLevels.levelDescriptor.name}"/>
@@ -315,10 +319,15 @@
         <constructor-arg name="predicate" ref="crafter.expiredDtItemPredicate"/>
     </bean>
 
+    <bean id="crafter.includeByUrlItemFilter" class="org.craftercms.engine.util.predicates.PredicateBasedFilter">
+        <constructor-arg name="predicate" ref="crafter.includeByUrlItemPredicate"/>
+    </bean>
+
     <util:list id="crafter.defaultItemPredicates">
         <ref bean="crafter.disabledItemPredicate"/>
         <ref bean="crafter.expiredItemPredicate"/>
         <ref bean="crafter.expiredDtItemPredicate"/>
+		<ref bean="crafter.includeByUrlItemPredicate"/>
     </util:list>
 
     <util:list id="crafter.defaultItemFilters">


### PR DESCRIPTION
SiteItemService return SiteItem only when matching allowed regexes
Adding exists() method for configuration support
https://github.com/craftersoftware/craftercms-e/issues/1148


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added URL-based filtering for items included in preview experiences.
  - Added configurable descriptor path rules to limit descriptor results to approved paths.
  - Added support for checking whether content exists at a specified path.

- **Improvements**
  - Preview experiences now apply the default URL inclusion filter automatically.
  - Streamlined configuration checks for determining whether site content is available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->