### PR TITLE
[8053] Remove deprecated getDescriptor API and update APIs in the js-sdk

### DIFF
--- a/js-sdk/CHANGELOG.md
+++ b/js-sdk/CHANGELOG.md
@@ -1,10 +1,27 @@
 # SDK Changelog
 
+## 5.0.0
+
+## @craftercms/content@5.0.0
+
+- "Get Descriptor" API removed (use getItem instead)
+- New `crafterConf.flatten` property which controls the `flatten` parameter of content services to recursively include linked content items
+
+## @craftercms/redux@5.0.0
+
+- "Get Descriptor" API removed (use getItem instead)
+- `getItem` action payload is now an object with `url` and optional `config` properties (previously a string URL)
+
+## @craftercms/classes4.4.1
+
+- New `crafterConf.flatten` property which controls the `flatten` parameter of content services to recursively include linked content items
+
 ## 4.2.0
-* [@craftercms/redux]:
-  * getTree action payload is now an object with `url` and `depth` properties.
-  * getNav action payload is now an object with `url`, `depth` and `cyrrebtPageUrl` properties.
-  * getNavBreadcrumb action payload is now an object with `url` and `root` properties.
+
+- [@craftercms/redux]:
+  - getTree action payload is now an object with `url` and `depth` properties.
+  - getNav action payload is now an object with `url`, `depth` and `cyrrebtPageUrl` properties.
+  - getNavBreadcrumb action payload is now an object with `url` and `root` properties.
 
 ## 4.1.3
 
@@ -14,6 +31,7 @@
 ## 4.1.2-support.2
 
 ### @craftercms/classes
+
 - Allow for an entire set of fetch config to be provided via crafterConf to be used in all GET requests (SdkService.httpGet)
 
 ## 4.1.2-1
@@ -31,16 +49,20 @@
 ## 4.1.0
 
 ### @craftercms/classes
+
 - Update search API endpoint from `/api/1/site/search/search.json` to `api/1/site/elasticsearch/search`.
 
 ### @craftercms/content
+
 - `urlTransform`, `getTree`, `getItem`, `getChildren` fix config argument to accept partial CrafterConfig
 - Update createQuery usage examples without SearchEngine parameter.
 
 ### @craftercms/models
+
 - Update Endpoints interface `ELASTICSEARCH` property to `SEARCH`.
 
 ### @craftercms/search
+
 - Remove ElasticQuery query implementation for ElasticSearch.
 - Use `Query` class instead of removed `ElasticQuery` class in `createQuery` function.
 - Update createQuery usage examples without SearchEngine parameter.
@@ -48,9 +70,11 @@
 ## 4.0.3
 
 ### All packages
-- Switching SDK versioning to follow the CrafterCMS release version 
+
+- Switching SDK versioning to follow the CrafterCMS release version
 
 ### @craftercms/content
+
 - Update `parseProps` (internally used by `parseDescriptor`) to include `orderDefault_f` (parsed as `orderInNav`) in the resulting ContentInstance.
 - Update `parseProps` and `parseDescriptor` options to receive `systemPropMap`, `ignoredProps`, `systemProps` to be used during parsing.
   - Note: modifying these props will require you to _open_ the `ContentInstance` interface and extend it accordingly.
@@ -62,6 +86,7 @@
 ## 2.0.7
 
 ### @craftercms/content
+
 - Fix `getDescriptor` crashing when `config` isn't supplied.
 
 ## 2.0.6
@@ -79,29 +104,35 @@
 ## 2.0.5
 
 ### @craftercms/content
+
 - Add prop data type parsing to `parsedDescriptor`
 
 ### @craftercms/ice
+
 - Add v4 support to `addAuthoringSupport`
 
 ## 2.0.4
 
 ### @craftercms/content
+
 - Fix `flatten` argument to getDescriptor getting lost/ignored
 
 ### @craftercms/models
+
 - Move types from other files into models package
 - Adding missing properties to NavigationItem interface
 
 ## 2.0.3
 
 ### @craftercms/classes
+
 - Change SDKService.httpGet to use fetch instead of rxjs.ajax
 - Fix fetch's mode (for cors)
 - Extend support for other fetch modes
 - Switch from using URLSearchParams to using query-string for the same purpose
 
 ## 2.0.2
+
 - Allow CORs
   - Use `crafterConf.configure({ cors: true, ... })` to enable CORs mode.
 - Fix `fetchIsAuthoring` and `addAuthoringSupport` not retrieving for baseUrl from `crafterConf`.
@@ -109,40 +140,49 @@
 ## 2.0.1
 
 ### @craftercms/redux
+
 - Upgrade to redux-observable 2
 
 ## 2.0.0
 
 ### All packages
+
 - Update to rxjs @ ^7
 
 ### @craftercms/search
+
 - Remove support for Solr
 
 ## 1.2.4
 
 ### @craftercms/content
+
 - Add ability to specify `flatten` for the `content_store/descriptor` endpoint (via the config argument of the function).
 - Make `parseDescriptor` be able to handle the deserialization products of the [recent `crafter-source` & `crafter-source-content-type-id` attribute additions](https://github.com/craftersoftware/craftercms/issues/4093).
 
 ### @craftercms/ice
+
 - [bugfix] Handle calls to `repaintPencils` before the dependency loader has been configured to avoid incorrect paths to load scripts/css from.
 - Extend support to react 17 (peerDependencies).
 
 ### misc
+
 - Upgrade to typescript 4+
-    - Fix type check issues that arose from upgrade.
+  - Fix type check issues that arose from upgrade.
 
 ## 1.2.3
 
 ### @craftercms/ice
+
 - Add `package.json` to `react` folder for prettier import usage and module bundler support
 
 ### @craftercms/content
+
 - Improve robustness of `parseDescriptor` function
 - Adds `preParseSearchResults` function
 
 ### misc
+
 - Added docs to package readme files for plain html/js usage
 - Removed the `browser` field from `package.json` files so bundlers can make use of es6 modules and tree shaking
 - Add npm badge to README files
@@ -150,14 +190,17 @@
 ## 1.2.2
 
 ### @craftercms/ice
+
 - Adds `reportNavigation` util for SPAs to report the current URL as the app navigates.
 
 ### misc
+
 - [internal] Bumps acorn version
 
 ## 1.2.1
 
 ### @craftercms/ice
+
 - Added validation addAuthoringSupport require.js load event
 - `getICEAttributes`
   - Auto calculates the label if not supplied based on the model param
@@ -165,11 +208,13 @@
   - Adds a _secret_ second argument so that wrapping utilities can identify themselves and errors as the entry point of the error
 
 ### @craftercms/utils
+
 - Renames misc/composeUrl param renamed for more accurate semantics
 
 ### @craftercms/content
+
 - `parseDescriptor`
-  - Fixes issue  where repeat group items with inner node selectors weren't parsed
+  - Fixes issue where repeat group items with inner node selectors weren't parsed
   - Improvements in `getItem` service parsing and component detection algorithms for `getItem` and `getDescriptor`
   - Adds ability to parse a `getTree` response into a flat content instance array
   - Adds `getChildren` response recognition and throws with non-parsable responses
@@ -177,62 +222,69 @@
 ## 1.2.0
 
 ### @craftercms/classes
+
 - SDKService refactored as stand alone functions; no need to use as class now though you may still use in the same way as in previous release if you prefer (backward compatible).
 
 ### @craftercms/content
+
 - Services refactored as stand alone functions; no need to use as class now though you may still use in the same way as in previous release if you prefer (backward compatible).
 - New `parseDescriptor` method which parses a `getDescriptor`, `getItem` or `GraphQL` response into a Content Instance (@see models/Content Instance).
 
 ### @craftercms/ice
+
 - First published
 - Publishing generic Crafter CMS In Context Editing (ICE) attribute retrieval functions for pencils and drop zones (drag and drop)
-    - getIceAttributes, 
-    - getDropZoneAttributes
-    - import/use in code by doing 
-        - `import { getIceAttributes } from '@craftercms/ice';`
-        - `import { getDropZoneAttributes } from '@craftercms/ice';`
+  - getIceAttributes,
+  - getDropZoneAttributes
+  - import/use in code by doing
+    - `import { getIceAttributes } from '@craftercms/ice';`
+    - `import { getDropZoneAttributes } from '@craftercms/ice';`
 - Publishing generic util functions
-    - repaintPencils: Repaints/repositions Crafter CMS In Context Editing pencils 
-    - fetchIsAuthoring: Interrogates the current origin server to determine if the site/app is running in Crafter CMS authoring or delivery environments
-    - addAuthoringSupport: Includes the necessary scripts to enable Crafter CMS authoring support
-    - `import { repaintPencils, fetchIsAuthoring, addAuthoringSupport } from '@craftercms/ice';` as needed
+  - repaintPencils: Repaints/repositions Crafter CMS In Context Editing pencils
+  - fetchIsAuthoring: Interrogates the current origin server to determine if the site/app is running in Crafter CMS authoring or delivery environments
+  - addAuthoringSupport: Includes the necessary scripts to enable Crafter CMS authoring support
+  - `import { repaintPencils, fetchIsAuthoring, addAuthoringSupport } from '@craftercms/ice';` as needed
 - Publishing React specific bindings via custom hooks:
-    - useICE, 
-    - useDropZone
-    - Import/use in code by doing
-        - `import { useICE } from '@craftercms/ice/esm5/react';`
-        - `import { useDropZone } from '@craftercms/ice/esm5/react';`
+  - useICE,
+  - useDropZone
+  - Import/use in code by doing
+    - `import { useICE } from '@craftercms/ice/esm5/react';`
+    - `import { useDropZone } from '@craftercms/ice/esm5/react';`
 - For direct usage in HTML `<script/>` tags, use the umd build
-    ```html
-    <script src="{path-to-your-scripts}/ice/bundles/ice.umd.js"></script>
-    <!-- ice/react requires the main ice script -->
-    <script src="{path-to-your-scripts}/ice/bundles/react/index.umd.js"></script>
-    ```
+  ```html
+  <script src="{path-to-your-scripts}/ice/bundles/ice.umd.js"></script>
+  <!-- ice/react requires the main ice script -->
+  <script src="{path-to-your-scripts}/ice/bundles/react/index.umd.js"></script>
+  ```
 - Notice the multi-platform builds published under
-    - bundles (umd)
-    - esm5 (module)
-    - es2015 (esm2015)
-    - fesm5
-    - fesm2015
+  - bundles (umd)
+  - esm5 (module)
+  - es2015 (esm2015)
+  - fesm5
+  - fesm2015
 
 ### @craftercms/models
+
 - Removed unpublished createLookupTable function; moved to @craftercms/utils
 - ContentInstance model added
 
 ### @craftercms/redux
+
 - redux, redux-observable & rxjs upgraded
 
 ### @craftercms/search
+
 - Service refactored as stand alone functions; no need to use as class now though you may still use in the same way as in previous release if you prefer (backward compatible).
 
 ### @craftercms/utils
+
 - Publishes createLookupTable util
 
 ### Global
+
 - Internal Yarn workspace set up
 - RxJS upgrade for all packages which have it as a dependency
 - Rollup config adjustments
 - Build script updates to print rollup output
 - Added `index.js` to fesm distributions
 - License updates
-

--- a/js-sdk/packages/classes/package.json
+++ b/js-sdk/packages/classes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@craftercms/classes",
-  "version": "0.0.0-PLACEHOLDER",
+  "version": "4.4.1",
   "description": "Crafter CMS utility classes for developing sites and applications",
   "main": "./bundles/classes.umd.js",
   "module": "./esm5/classes.js",
@@ -26,8 +26,8 @@
     "test": "mocha"
   },
   "dependencies": {
-    "@craftercms/models": "0.0.0-PLACEHOLDER",
-    "@craftercms/utils": "0.0.0-PLACEHOLDER",
+    "@craftercms/models": "4.3.1",
+    "@craftercms/utils": "4.3.0",
     "query-string": "^9.1.0"
   },
   "devDependencies": {

--- a/js-sdk/packages/classes/src/config.ts
+++ b/js-sdk/packages/classes/src/config.ts
@@ -34,7 +34,8 @@ const DEFAULTS: CrafterConfig = {
   },
   fetchConfig: {},
   contentTypeRegistry: {},
-  headers: {}
+  headers: {},
+  flatten: false
 };
 
 class ConfigManager {
@@ -54,10 +55,12 @@ class ConfigManager {
   subscribe(observerOrNext: ObserverOrNext<CrafterConfig>): Subscription;
   subscribe<T extends CrafterConfig, R>(
     observerOrNext: ObserverOrNext<R>,
-    ...operators: OperatorFunction<T, R>[]): Subscription;
+    ...operators: OperatorFunction<T, R>[]
+  ): Subscription;
   subscribe<T extends CrafterConfig, R>(
     observerOrNext: ObserverOrNext<R>,
-    ...operators: OperatorFunction<T, R>[]): Subscription {
+    ...operators: OperatorFunction<T, R>[]
+  ): Subscription {
     return this.config$.pipe.apply(this.config$, operators).subscribe(observerOrNext);
   }
 
@@ -66,18 +69,19 @@ class ConfigManager {
   entry(propPath: string, nextValue?: any): any | void {
     const config = this.config;
     if (!propPath) return { ...config };
-    const getter = (nextValue == null);
+    const getter = nextValue == null;
     const path = propPath.split('.');
-    const prop = (!getter) && (path.pop());
+    const prop = !getter && path.pop();
     const value = (() => {
       try {
         const l = path.length - 1;
-        return path.length ? path.reduce(
-          (cfg, property, i) =>
-            getter && (l === i) && isPlainObject(cfg[property])
-              ? { ...cfg[property] }
-              : cfg[property],
-          config) : config;
+        return path.length
+          ? path.reduce(
+              (cfg, property, i) =>
+                getter && l === i && isPlainObject(cfg[property]) ? { ...cfg[property] } : cfg[property],
+              config
+            )
+          : config;
       } catch (e) {
         log(`Error retrieving crafter config prop '${propPath}': ${e.message || e}`, log.WARN);
         return null;
@@ -85,10 +89,7 @@ class ConfigManager {
     })();
     if (getter) {
       return value;
-    } else if (
-      (prop in value) ||
-      (path[path.length - 1] === 'contentTypeRegistry')
-    ) {
+    } else if (prop in value || path[path.length - 1] === 'contentTypeRegistry') {
       this.publishConfig({ ...value, [prop]: nextValue });
     }
   }
@@ -102,8 +103,11 @@ class ConfigManager {
     if ('cors' in mixin) {
       const { cors } = mixin;
       mixin.fetchConfig = mixin.fetchConfig ?? {};
-      mixin.fetchConfig.mode = typeof cors === 'boolean' ? cors ? 'cors' : 'no-cors' : cors;
-      console.log('%c[CrafterCMS] The `crafterConf.cors` property is deprecated and will be removed in following versions. Use `fetchConfig.mode` instead.', 'color:red');
+      mixin.fetchConfig.mode = typeof cors === 'boolean' ? (cors ? 'cors' : 'no-cors') : cors;
+      console.log(
+        '%c[CrafterCMS] The `crafterConf.cors` property is deprecated and will be removed in following versions. Use `fetchConfig.mode` instead.',
+        'color:red'
+      );
     }
     return extendDeepExistingProps({ ...this.config }, mixin);
   }

--- a/js-sdk/packages/content/README.md
+++ b/js-sdk/packages/content/README.md
@@ -24,7 +24,8 @@ All of Crafter CMS packages can be used either via npm or in plain html/javascri
 **Tip**: Once you've imported the scripts, type `craftercms` on your browser's dev tools console to inspect the package(s)
 
 #### Vanilla html/js example
- ```html
+
+```html
 <div id="myFeature"></div>
 <script src="https://unpkg.com/rxjs"></script>
 <script src="https://unpkg.com/@craftercms/utils"></script>
@@ -32,47 +33,44 @@ All of Crafter CMS packages can be used either via npm or in plain html/javascri
 <script src="https://unpkg.com/@craftercms/content"></script>
 <script>
   (function ({ content }, { operators }) {
-
-    content.getItem(
-      '/site/website/index.xml',
-      { baseUrl: 'http://localhost:8080', site: 'editorial' }
-    ).pipe(
-      operators.map(content.parseDescriptor)
-    ).subscribe((model) => {
-      const elem = document.querySelector('#myFeature');
-      Object.entries(model).forEach(([fieldId, value]) => {
-        if (fieldId !== 'craftercms') {
-          const el = document.createElement('div');
-          el.innerText = `${fieldId}: ${value}`;
-          elem.appendChild(el);
-        }
+    content
+      .getItem('/site/website/index.xml', { baseUrl: 'http://localhost:8080', site: 'editorial' })
+      .pipe(operators.map(content.parseDescriptor))
+      .subscribe((model) => {
+        const elem = document.querySelector('#myFeature');
+        Object.entries(model).forEach(([fieldId, value]) => {
+          if (fieldId !== 'craftercms') {
+            const el = document.createElement('div');
+            el.innerText = `${fieldId}: ${value}`;
+            elem.appendChild(el);
+          }
+        });
       });
-    });
-
   })(craftercms, rxjs);
 </script>
 ```
 
 ### Service pre-configuration
+
 You may pre-configure content services to a certain configuration to then you may omit the config param on subsequent calls to services
 
 ```typescript
-  import { Item } from '@craftercms/models';
-  import { getItem } from '@craftercms/content';
-  import { crafterConf } from '@craftercms/classes';
+import { Item } from '@craftercms/models';
+import { getItem } from '@craftercms/content';
+import { crafterConf } from '@craftercms/classes';
 
-  // Configure crafter services "globally". Your config will be cached.
-  // All content services use the specified configuration on subsequent calls.
-  crafterConf.configure({
-    baseUrl: 'http://authoring.company.com',
-    site: 'editorial'
-  });
+// Configure crafter services "globally". Your config will be cached.
+// All content services use the specified configuration on subsequent calls.
+crafterConf.configure({
+  baseUrl: 'http://authoring.company.com',
+  site: 'editorial'
+});
 
-  // Second param "config" will use "http://authoring.company.com" as
-  // crafter base url and "editorial" as the site to query
-  getItem('/site/website/index.xml').subscribe((item: Item) => {
-    console.log(item);
-  });
+// Second param "config" will use "http://authoring.company.com" as
+// crafter base url and "editorial" as the site to query
+getItem('/site/website/index.xml').subscribe((item: Item) => {
+  console.log(item);
+});
 ```
 
 ## Package Index
@@ -82,13 +80,14 @@ directly importing as a script in the browser, these functions will be under the
 named `craftercms.content` (i.e. `window.craftercms.content`).
 
 ### parseDescriptor
+
 Parse a [Descriptor](https://github.com/craftersoftware/craftercms/blob/support/4.x/js-sdk/packages/models/src/descriptor.ts), [Item](https://github.com/craftersoftware/craftercms/blob/support/4.x/js-sdk/packages/models/src/item.ts) or a GraphQL response into a [Content Instance](https://github.com/craftersoftware/craftercms/blob/support/4.x/js-sdk/packages/models/src/ContentInstance.ts). It could also be a collection of any of these types.
 
 `parseDescriptor(response: Descriptor | Item | GraphQLResponse | Descriptor[] | Item[] | GraphQLResponse)`
 
-| Parameters    |                |
-| ------------- |:--------------:|
-| response      | The response of a getItem, getDescriptor or GraphQL fetch call |
+| Parameters |                                                 |
+| ---------- | :---------------------------------------------: |
+| response   | The response of a getItem or GraphQL fetch call |
 
 #### Returns
 
@@ -96,27 +95,28 @@ Parse a [Descriptor](https://github.com/craftersoftware/craftercms/blob/support/
 
 #### Examples
 
-- If you want a cleaner/parsed response, you may use `parseDescriptor` util to parse the response for you. You may use it to parse getItem, getDescriptor or GraphQL responses.
+- If you want a cleaner/parsed response, you may use `parseDescriptor` util to parse the response for you. You may use it to parse getItem or GraphQL responses.
 
 ```typescript
-  import { map } from 'rxjs/operators';
-  import { ContentInstance } from '@craftercms/models';
-  import { getChildren, getItem, parseDescriptor } from '@craftercms/content';
+import { map } from 'rxjs/operators';
+import { ContentInstance } from '@craftercms/models';
+import { getChildren, getItem, parseDescriptor } from '@craftercms/content';
 
-  getItem('/site/website/index.xml', { site: 'editorial' }).pipe(
-    map(parseDescriptor)
-  ).subscribe((content: ContentInstance) => {
+getItem('/site/website/index.xml', { site: 'editorial' })
+  .pipe(map(parseDescriptor))
+  .subscribe((content: ContentInstance) => {
     console.log(content);
   });
 
-  getChildren('/site/website', { site: 'editorial' }).pipe(
-    map(parseDescriptor)
-  ).subscribe((content: ContentInstance[]) => {
+getChildren('/site/website', { site: 'editorial' })
+  .pipe(map(parseDescriptor))
+  .subscribe((content: ContentInstance[]) => {
     console.log(content);
   });
 ```
 
 ### preParseSearchResults
+
 Inspects and parses elasticsearch hits and pre-parses objects before they can be sent to parseDescriptor
 @see https://github.com/craftersoftware/craftercms/issues/4057
 
@@ -128,32 +128,35 @@ search(
   createQuery({
     query: {
       bool: {
-        filter: [/*...*/]
+        filter: [
+          /*...*/
+        ]
       }
     }
   }),
   { baseUrl: 'http://localhost:8080', site: 'editorial' }
-).pipe(
-  map(({ hits, ...rest }) => ({
-    ...rest,
-    hits: hits.map(({ _source }) => parseDescriptor(
-      preParseSearchResults(_source)
-    ))
-  }))
-).subscribe((results) => {
-  // Do stuff with results...
-});
+)
+  .pipe(
+    map(({ hits, ...rest }) => ({
+      ...rest,
+      hits: hits.map(({ _source }) => parseDescriptor(preParseSearchResults(_source)))
+    }))
+  )
+  .subscribe((results) => {
+    // Do stuff with results...
+  });
 ```
 
 ### Get Item
+
 Get an Item from the content store.
 
 `getItem(path: string, config?: CrafterConfig)`
 
-| Parameters    |                                                                                                                                                                                 |
-| ------------- |:-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------:|
-| path          |                                                                      The item’s path in the content store                                                                       |
-| config        | Crafter configuration. Optional. Default value in [CrafterConfig](https://github.com/craftersoftware/craftercms/blob/support/4.x/js-sdk/packages/models/src/crafter-config.ts). |
+| Parameters |                                                                                                                                                                                 |
+| ---------- | :-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------: |
+| path       |                                                                      The item’s path in the content store                                                                       |
+| config     | Crafter configuration. Optional. Default value in [CrafterConfig](https://github.com/craftersoftware/craftercms/blob/support/4.x/js-sdk/packages/models/src/crafter-config.ts). |
 
 #### Returns
 
@@ -164,75 +167,38 @@ Get an Item from the content store.
 - Get the index page from the site:
 
 ```typescript
-  import { Item } from '@craftercms/models';
-  import { getItem } from '@craftercms/content';
+import { Item } from '@craftercms/models';
+import { getItem } from '@craftercms/content';
 
-  getItem('/site/website/index.xml', { site: 'editorial' }).subscribe((item: Item) => {
-    console.log(item);
-  });
+getItem('/site/website/index.xml', { site: 'editorial' }).subscribe((item: Item) => {
+  console.log(item);
+});
 ```
 
 - If you want a cleaner/parsed response, you may use `parseDescriptor` util to parse the response for you.
 
 ```typescript
-  import { map } from 'rxjs/operators';
-  import { ContentInstance } from '@craftercms/models';
-  import { getItem, parseDescriptor } from '@craftercms/content';
+import { map } from 'rxjs/operators';
+import { ContentInstance } from '@craftercms/models';
+import { getItem, parseDescriptor } from '@craftercms/content';
 
-  getItem('/site/website/index.xml', { site: 'editorial' }).pipe(
-    map(parseDescriptor)
-  ).subscribe((content: ContentInstance) => {
-    console.log(content);
-  });
-```
-
-### Get Descriptor
-Get the descriptor data of an Item in the content store.
-
-`getDescriptor(path: string, config?: CrafterConfig)`
-
-| Parameters    |                |
-| ------------- |:--------------:|
-| path          | The item’s path in the content store |
-| config        | Crafter configuration. Optional. Default value in [here](https://github.com/craftersoftware/craftercms/blob/support/4.x/js-sdk/packages/models/README.md#CrafterConfig). |
-
-#### Returns
-
-[Descriptor](https://github.com/craftersoftware/craftercms/blob/support/4.x/js-sdk/packages/models/README.md#Descriptor) - from the content store
-
-#### Examples
-
-- Get the index page from the site:
-
-```typescript
-  import { map } from 'rxjs/operators';
-  import { getDescriptor, parseDescriptor } from '@craftercms/content';
-  import { Descriptor, ContentInstance } from '@craftercms/models';
-
-  // Example 1: Supplying config inline, Descriptor response...
-  getDescriptor('/site/website/index.xml', { site: 'editorial' }).subscribe((descriptor: Descriptor) => {
-    console.log(descriptor);
-  });
-
-  // Example 2:
-  // - Omit config (must have configured earlier @see Usage section above)
-  // - Parse the response
-  getDescriptor('/site/website/index.xml').pipe(
-    map(parseDescriptor) // Optional. Use for a cleaner parsed response.
-  ).subscribe((content: ContentInstance) => {
+getItem('/site/website/index.xml', { site: 'editorial' })
+  .pipe(map(parseDescriptor))
+  .subscribe((content: ContentInstance) => {
     console.log(content);
   });
 ```
 
 ### Get Children
+
 Get the list of Items directly under a folder in the content store.
 
 `getChildren(path: string, config?: CrafterConfig)`
 
-| Parameters    |                |
-| ------------- |:--------------:|
-| path          | The folder’s path |
-| config        | Crafter configuration. Optional. Default value in [here](https://github.com/craftersoftware/craftercms/blob/support/4.x/js-sdk/packages/models/README.md#CrafterConfig). |
+| Parameters |                                                                                                                                                                          |
+| ---------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------: |
+| path       |                                                                            The folder’s path                                                                             |
+| config     | Crafter configuration. Optional. Default value in [here](https://github.com/craftersoftware/craftercms/blob/support/4.x/js-sdk/packages/models/README.md#CrafterConfig). |
 
 #### Returns
 
@@ -243,20 +209,21 @@ Get the list of Items directly under a folder in the content store.
 - Get the children items under root folder from the site:
 
 ```typescript
-  import { getChildren } from '@craftercms/content';
+import { getChildren } from '@craftercms/content';
 
-  // Example 1: Supplying config inline
-  getChildren('/site/website', { site: 'editorial' }).subscribe((children) => {
-    console.log(children);
-  });
+// Example 1: Supplying config inline
+getChildren('/site/website', { site: 'editorial' }).subscribe((children) => {
+  console.log(children);
+});
 
-  // Example 2: Omits the config param (must have been previously configured, see Usage section above)
-  getChildren('/site/website').subscribe((children) => {
-    console.log(children);
-  });
+// Example 2: Omits the config param (must have been previously configured, see Usage section above)
+getChildren('/site/website').subscribe((children) => {
+  console.log(children);
+});
 ```
 
 ### Get Tree
+
 Get the complete Item hierarchy under the specified folder in the content store.
 
 ```typescript
@@ -269,11 +236,11 @@ getTree(path: string, depth: number | Partial<CrafterConfig> = 1, config?: Parti
 
 When the second argument is a configuration object, depth defaults to `1`.
 
-| Parameters    |                |
-| ------------- |:--------------:|
-| path          | The folder’s path |
-| depth         | Amount of levels to include. Optional. When omitted or when config is passed as the second argument, default is `1` |
-| config        | Crafter configuration. Optional. Default value in [here](https://github.com/craftersoftware/craftercms/blob/support/4.x/js-sdk/packages/models/README.md#CrafterConfig). |
+| Parameters |                                                                                                                                                                          |
+| ---------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------: |
+| path       |                                                                            The folder’s path                                                                             |
+| depth      |                           Amount of levels to include. Optional. When omitted or when config is passed as the second argument, default is `1`                            |
+| config     | Crafter configuration. Optional. Default value in [here](https://github.com/craftersoftware/craftercms/blob/support/4.x/js-sdk/packages/models/README.md#CrafterConfig). |
 
 #### Returns
 
@@ -284,39 +251,40 @@ When the second argument is a configuration object, depth defaults to `1`.
 - Get the items tree under root folder from the site:
 
 ```typescript
-  import { getTree } from '@craftercms/content';
+import { getTree } from '@craftercms/content';
 
-  // Example 1: Services pre-configured, default depth (1)
-  getTree('/site/website').subscribe((tree) => {
-    console.log(tree);
-  });
+// Example 1: Services pre-configured, default depth (1)
+getTree('/site/website').subscribe((tree) => {
+  console.log(tree);
+});
 
-  // Example 2: Services pre-configured (see "Usage" section above), depth only
-  getTree('/site/website', 3).subscribe((tree) => {
-    console.log(tree);
-  });
+// Example 2: Services pre-configured (see "Usage" section above), depth only
+getTree('/site/website', 3).subscribe((tree) => {
+  console.log(tree);
+});
 
-  // Example 3: Depth and config supplied inline
-  getTree('/site/website', 3, { site: 'editorial' }).subscribe((tree) => {
-    console.log(tree);
-  });
+// Example 3: Depth and config supplied inline
+getTree('/site/website', 3, { site: 'editorial' }).subscribe((tree) => {
+  console.log(tree);
+});
 
-  // Example 4: Config as second argument (depth defaults to 1)
-  getTree('/site/website', { site: 'editorial' }).subscribe((tree) => {
-    console.log(tree);
-  });
+// Example 4: Config as second argument (depth defaults to 1)
+getTree('/site/website', { site: 'editorial' }).subscribe((tree) => {
+  console.log(tree);
+});
 ```
 
 ### Get Navigation Tree
+
 Returns the navigation tree with the specified depth for the specified store URL.
 
 `getNavTree(path: string, depth?: number, currentPageUrl?: string, config?: CrafterConfig)`
 
-| Parameters     |                |
-| -------------- |:--------------:|
-| path           | The folder’s path |
-| depth          | Amount of levels to include. Optional. Default is `1` |
-| currentPageUrl | The URL of the current page. Optional. Default is `''` |
+| Parameters     |                                                                                                                                                                          |
+| -------------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------: |
+| path           |                                                                            The folder’s path                                                                             |
+| depth          |                                                          Amount of levels to include. Optional. Default is `1`                                                           |
+| currentPageUrl |                                                          The URL of the current page. Optional. Default is `''`                                                          |
 | config         | Crafter configuration. Optional. Default value in [here](https://github.com/craftersoftware/craftercms/blob/support/4.x/js-sdk/packages/models/README.md#CrafterConfig). |
 
 #### Returns
@@ -328,29 +296,32 @@ Returns the navigation tree with the specified depth for the specified store URL
 - Get the navigation tree of the root folder from the site (depth = 3):
 
 ```typescript
-  import { getNavTree } from '@craftercms/content';
+import { getNavTree } from '@craftercms/content';
 
-  // Example 1: Config supplied inline
-  getNavTree('/site/website', 3, '', { site: 'editorial', baseUrl: 'http://localhost:8080', headers: {} }).subscribe((tree) => {
+// Example 1: Config supplied inline
+getNavTree('/site/website', 3, '', { site: 'editorial', baseUrl: 'http://localhost:8080', headers: {} }).subscribe(
+  (tree) => {
     console.log(tree);
-  });
+  }
+);
 
-  // Example 2: Services pre-configured (see "Usage" section above), config param omitted.
-  getNavTree('/site/website', 3).subscribe((tree) => {
-    console.log(tree);
-  });
+// Example 2: Services pre-configured (see "Usage" section above), config param omitted.
+getNavTree('/site/website', 3).subscribe((tree) => {
+  console.log(tree);
+});
 ```
 
 ### Get Navigation Breadcrumb
+
 Returns the navigation items that form the breadcrumb for the specified store URL.
 
 `getNavBreadcrumb(path: string, root?: string, config?: CrafterConfig)`
 
-| Parameters     |                |
-| -------------- |:--------------:|
-| path            | The folder’s path |
-| root           | the root URL, basically the starting point of the breadcrumb. Optional. Default is `''` |
-| config        | Crafter configuration. Optional. Default value in [here](https://github.com/craftersoftware/craftercms/blob/support/4.x/js-sdk/packages/models/README.md#CrafterConfig). |
+| Parameters |                                                                                                                                                                          |
+| ---------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------: |
+| path       |                                                                            The folder’s path                                                                             |
+| root       |                                         the root URL, basically the starting point of the breadcrumb. Optional. Default is `''`                                          |
+| config     | Crafter configuration. Optional. Default value in [here](https://github.com/craftersoftware/craftercms/blob/support/4.x/js-sdk/packages/models/README.md#CrafterConfig). |
 
 #### Returns
 
@@ -361,29 +332,30 @@ Returns the navigation items that form the breadcrumb for the specified store UR
 - Get the breadcrumb for the root folder from the site:
 
 ```typescript
-  import { getNavBreadcrumb } from '@craftercms/content';
+import { getNavBreadcrumb } from '@craftercms/content';
 
-  // Example 1: Config supplied inline
-  getNavBreadcrumb('/site/website').subscribe((navBreadcrumb) => {
-    console.log(navBreadcrumb);
-  });
+// Example 1: Config supplied inline
+getNavBreadcrumb('/site/website').subscribe((navBreadcrumb) => {
+  console.log(navBreadcrumb);
+});
 
-  // Example 2: Services pre-configured (see "Usage" section above), config param omitted.
-  getNavBreadcrumb('/site/website').subscribe((navBreadcrumb) => {
-    console.log(navBreadcrumb);
-  });
+// Example 2: Services pre-configured (see "Usage" section above), config param omitted.
+getNavBreadcrumb('/site/website').subscribe((navBreadcrumb) => {
+  console.log(navBreadcrumb);
+});
 ```
 
 ### Transform
+
 Transforms a URL, based on the current site’s configuration.
 
 - `urlTransform(transformerName: string, path: string, config?: Partial<CrafterConfig>)`
 
-| Parameters      |                |
-| --------------- |:--------------:|
-| transformerName | Name of the transformer to apply |
-| path             | URL that will be transformed |
-| config        | Crafter configuration. Optional. Default value in [here](https://github.com/craftersoftware/craftercms/blob/support/4.x/js-sdk/packages/models/README.md#CrafterConfig). |
+| Parameters      |                                                                                                                                                                          |
+| --------------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------: |
+| transformerName |                                                                     Name of the transformer to apply                                                                     |
+| path            |                                                                       URL that will be transformed                                                                       |
+| config          | Crafter configuration. Optional. Default value in [here](https://github.com/craftersoftware/craftercms/blob/support/4.x/js-sdk/packages/models/README.md#CrafterConfig). |
 
 #### Returns
 
@@ -394,33 +366,33 @@ string - URL transformed according to transformer applied.
 - Transform a store path into a render path
 
 ```typescript
-  import { urlTransform } from '@craftercms/content';
+import { urlTransform } from '@craftercms/content';
 
-  // Example 1: Config supplied inline
-  urlTransform('storeUrlToRenderUrl', '/site/website/style/index.xml', { site: 'editorial' }).subscribe((webUrl) => {
-    console.log(webUrl); // "/style"
-  });
+// Example 1: Config supplied inline
+urlTransform('storeUrlToRenderUrl', '/site/website/style/index.xml', { site: 'editorial' }).subscribe((webUrl) => {
+  console.log(webUrl); // "/style"
+});
 
-  // Example 2: Services pre-configured (see "Usage" section above), config param omitted.
-  urlTransform('storeUrlToRenderUrl', '/site/website/style/index.xml').subscribe((webUrl) => {
-    console.log(webUrl); // "/style"
-  });
+// Example 2: Services pre-configured (see "Usage" section above), config param omitted.
+urlTransform('storeUrlToRenderUrl', '/site/website/style/index.xml').subscribe((webUrl) => {
+  console.log(webUrl); // "/style"
+});
 ```
 
 - Transform a render path into a store path
 
 ```typescript
-  import { urlTransform } from '@craftercms/content';
+import { urlTransform } from '@craftercms/content';
 
-  // Assuming that you already set the configuration (as explained above)
+// Assuming that you already set the configuration (as explained above)
 
-  // Example 1: Config supplied inline
-  urlTransform('renderUrlToStoreUrl', '/technology', { site: 'editorial' }).subscribe((path) => {
-    console.log(path); // "/site/website/technology/index.xml"
-  });
+// Example 1: Config supplied inline
+urlTransform('renderUrlToStoreUrl', '/technology', { site: 'editorial' }).subscribe((path) => {
+  console.log(path); // "/site/website/technology/index.xml"
+});
 
-  // Example 2: Services pre-configured (see "Usage" section above), config param omitted.
-  urlTransform('renderUrlToStoreUrl', '/technology').subscribe((path) => {
-    console.log(path); // "/site/website/technology/index.xml"
-  })
+// Example 2: Services pre-configured (see "Usage" section above), config param omitted.
+urlTransform('renderUrlToStoreUrl', '/technology').subscribe((path) => {
+  console.log(path); // "/site/website/technology/index.xml"
+});
 ```

--- a/js-sdk/packages/content/package.json
+++ b/js-sdk/packages/content/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@craftercms/content",
-  "version": "0.0.0-PLACEHOLDER",
+  "version": "5.0.0",
   "description": "Crafter CMS services for content and navigation retrieval",
   "main": "./bundles/content.umd.js",
   "module": "./esm5/content.js",
@@ -26,9 +26,9 @@
     "test": "mocha"
   },
   "dependencies": {
-    "@craftercms/classes": "0.0.0-PLACEHOLDER",
-    "@craftercms/models": "0.0.0-PLACEHOLDER",
-    "@craftercms/utils": "0.0.0-PLACEHOLDER",
+    "@craftercms/classes": "4.4.1",
+    "@craftercms/models": "4.3.1",
+    "@craftercms/utils": "4.3.0",
     "rxjs": "^7.8.1"
   },
   "devDependencies": {

--- a/js-sdk/packages/content/src/ContentStoreService.ts
+++ b/js-sdk/packages/content/src/ContentStoreService.ts
@@ -16,7 +16,7 @@
 
 import { Observable } from 'rxjs';
 import { crafterConf, SDKService } from '@craftercms/classes';
-import { CrafterConfig, Descriptor, Item } from '@craftercms/models';
+import { CrafterConfig, Item } from '@craftercms/models';
 import { composeUrl } from '@craftercms/utils';
 import { map } from 'rxjs/operators';
 
@@ -29,7 +29,11 @@ export function getItem(path: string, config: Partial<CrafterConfig>): Observabl
 export function getItem(path: string, config?: Partial<CrafterConfig>): Observable<Item> {
   config = crafterConf.mix(config);
   const requestURL = composeUrl(config, config.endpoints.GET_ITEM_URL);
-  return SDKService.httpGet(requestURL, { url: path, crafterSite: config.site }, config.headers);
+  return SDKService.httpGet(
+    requestURL,
+    { url: path, crafterSite: config.site, flatten: Boolean(config?.flatten) },
+    config.headers
+  );
 }
 
 export interface GetDescriptorConfig extends CrafterConfig {
@@ -45,11 +49,15 @@ export function getDescriptor(path: string): Observable<Descriptor>;
 export function getDescriptor(path: string, config: Partial<GetDescriptorConfig>): Observable<Descriptor>;
 export function getDescriptor(path: string, config?: Partial<GetDescriptorConfig>): Observable<Descriptor> {
   let cfg = crafterConf.mix(config);
-  return SDKService.httpGet<Descriptor>(composeUrl(cfg, cfg.endpoints.GET_DESCRIPTOR), {
-    url: path,
-    crafterSite: cfg.site,
-    flatten: Boolean(config?.flatten)
-  }, cfg.headers).pipe(
+  return SDKService.httpGet<Descriptor>(
+    composeUrl(cfg, cfg.endpoints.GET_DESCRIPTOR),
+    {
+      url: path,
+      crafterSite: cfg.site,
+      flatten: Boolean(config?.flatten)
+    },
+    cfg.headers
+  ).pipe(
     // Manually introduce the path into the response as descriptor endpoint does not return it.
     map((descriptor: Descriptor) => {
       let prop = typeof descriptor.page === 'undefined' ? 'component' : 'page';
@@ -72,7 +80,11 @@ export function getChildren(path: string, config: Partial<CrafterConfig>): Obser
 export function getChildren(path: string, config?: Partial<CrafterConfig>): Observable<Item[]> {
   config = crafterConf.mix(config);
   const requestURL = composeUrl(config, config.endpoints.GET_CHILDREN);
-  return SDKService.httpGet(requestURL, { url: path, crafterSite: config.site }, config.headers);
+  return SDKService.httpGet(
+    requestURL,
+    { url: path, crafterSite: config.site, flatten: Boolean(config?.flatten) },
+    config.headers
+  );
 }
 
 /**
@@ -84,19 +96,26 @@ export function getTree(path: string): Observable<Item>;
 export function getTree(path: string, depth: number): Observable<Item>;
 export function getTree(path: string, depth: number, config: Partial<CrafterConfig>): Observable<Item>;
 export function getTree(path: string, config: Partial<CrafterConfig>): Observable<Item>;
-export function getTree(path: string, depth: number | Partial<CrafterConfig> = 1, config?: Partial<CrafterConfig>): Observable<Item> {
+export function getTree(
+  path: string,
+  depth: number | Partial<CrafterConfig> = 1,
+  config?: Partial<CrafterConfig>
+): Observable<Item> {
   if (typeof depth === 'object') {
     config = depth;
     depth = 1;
   }
   config = crafterConf.mix(config);
   const requestURL = composeUrl(config, config.endpoints.GET_TREE);
-  return SDKService.httpGet(requestURL, { url: path, depth, crafterSite: config.site }, config.headers);
+  return SDKService.httpGet(
+    requestURL,
+    { url: path, depth, crafterSite: config.site, flatten: Boolean(config?.flatten) },
+    config.headers
+  );
 }
 
 export const ContentStoreService = {
   getItem,
-  getDescriptor,
   getChildren,
   getTree
 };

--- a/js-sdk/packages/content/src/utils.ts
+++ b/js-sdk/packages/content/src/utils.ts
@@ -14,9 +14,9 @@
  * along with this program. If not, see http://www.gnu.org/licenses/.
  */
 
-import { ContentInstance, Descriptor, DescriptorResponse, Item } from '@craftercms/models';
+import type { ContentInstance, CrafterConfig, Descriptor, DescriptorResponse, Item } from '@craftercms/models';
 import { urlTransform } from './UrlTransformationService';
-import { getDescriptor, GetDescriptorConfig } from './ContentStoreService';
+import { getItem } from './ContentStoreService';
 import { map, switchMap } from 'rxjs/operators';
 import { Observable } from 'rxjs';
 
@@ -26,7 +26,7 @@ export const systemPropMap = {
   objectId: 'id',
   localId: 'path',
   'file-name': 'fileName',
-  'file__name': 'fileName',
+  file__name: 'fileName',
   placeInNav: 'placeInNav',
   'internal-name': 'label',
   internal__name: 'label',
@@ -51,12 +51,15 @@ export const ignoredProps = [
 export const systemProps = Object.keys(systemPropMap).concat(Object.values(systemPropMap));
 
 function mixParseDescriptorOptions(options: ParseDescriptorOptions = {}): ParseDescriptorOptions {
-  return Object.assign({
-    systemPropMap,
-    ignoredProps,
-    systemProps,
-    parseFieldValueTypes: false
-  }, options);
+  return Object.assign(
+    {
+      systemPropMap,
+      ignoredProps,
+      systemProps,
+      parseFieldValueTypes: false
+    },
+    options
+  );
 }
 
 export type ParseDescriptorOptions = Partial<{
@@ -90,10 +93,10 @@ export function parseDescriptor(
     // The getChildren call contains certain items that can't be parsed into content items.
     throw new Error(
       '[parseDescriptor] Invalid descriptor supplied. Did you call ' +
-      'parseDescriptor with a `getChildren` API response? The `getChildren` API ' +
-      'response may contain certain items that are not parsable into ContentInstances. ' +
-      'Try a different API (getItem, getDescriptor or getTree) or filter out the metadata ' +
-      'items which descriptorDom property has a `page` or `component` property with the content item.'
+        'parseDescriptor with a `getChildren` API response? The `getChildren` API ' +
+        'response may contain certain items that are not parsable into ContentInstances. ' +
+        'Try a different API (getItem or getTree) or filter out the metadata ' +
+        'items which descriptorDom property has a `page` or `component` property with the content item.'
     );
   }
   let parsed: ContentInstance = {
@@ -116,11 +119,7 @@ export function parseProps<Props = object, Target = object>(
   options?: ParseDescriptorOptions
 ): Target {
   options = mixParseDescriptorOptions(options);
-  let {
-    systemPropMap,
-    ignoredProps,
-    systemProps
-  } = options;
+  let { systemPropMap, ignoredProps, systemProps } = options;
   Object.entries(props).forEach(([prop, value]) => {
     if (ignoredProps.includes(prop)) {
       return; // continue, skip prop.
@@ -158,18 +157,18 @@ export function parseProps<Props = object, Target = object>(
       }
       parsed[prop] = parsed[prop].map((item) => {
         const { key, value, component, include } = item;
-        if ((item.component) || (item.key && item.include)) {
+        if (item.component || (item.key && item.include)) {
           // Components
           const newComponent = {
             label: value,
             ...component,
             path: key?.startsWith('/')
               ? key
-              : (
-                include?.startsWith('/')
-                  ? include
-                  : component?.path ? component.path : null
-              )
+              : include?.startsWith('/')
+                ? include
+                : component?.path
+                  ? component.path
+                  : null
           };
           return parseDescriptor(newComponent, options);
         } else {
@@ -178,9 +177,7 @@ export function parseProps<Props = object, Target = object>(
         }
       });
     } else {
-      parsed[prop] = value != null
-        ? options.parseFieldValueTypes ? parseFieldValue(prop, value) : value
-        : null;
+      parsed[prop] = value != null ? (options.parseFieldValueTypes ? parseFieldValue(prop, value) : value) : null;
     }
   });
   return parsed;
@@ -210,32 +207,38 @@ export function parseFieldValue(propName: string, propValue: any): number | stri
 }
 
 export function fetchModelByPath(path: string): Observable<ContentInstance>;
-export function fetchModelByPath(path: string, options: Partial<GetDescriptorConfig & ParseDescriptorOptions>): Observable<ContentInstance>;
 export function fetchModelByPath(
   path: string,
-  options?: Partial<GetDescriptorConfig & ParseDescriptorOptions>
+  options: Partial<CrafterConfig & ParseDescriptorOptions>
+): Observable<ContentInstance>;
+export function fetchModelByPath(
+  path: string,
+  options?: Partial<CrafterConfig & ParseDescriptorOptions>
 ): Observable<ContentInstance> {
   let pdo = mixParseDescriptorOptions({ parseFieldValueTypes: true, ...options });
-  return getDescriptor(path, { flatten: true, ...options }).pipe(
-    map((descriptor) => parseDescriptor(descriptor, pdo))
+  return getItem(path, { flatten: true, ...options }).pipe(
+    map(({ descriptorDom }) => parseDescriptor(descriptorDom, pdo))
   );
 }
 
 export function fetchModelByUrl(webUrl: string): Observable<ContentInstance>;
-export function fetchModelByUrl(webUrl: string, options: Partial<GetDescriptorConfig & ParseDescriptorOptions>): Observable<ContentInstance>;
 export function fetchModelByUrl(
   webUrl: string,
-  options?: Partial<GetDescriptorConfig & ParseDescriptorOptions>
+  options: Partial<CrafterConfig & ParseDescriptorOptions>
+): Observable<ContentInstance>;
+export function fetchModelByUrl(
+  webUrl: string,
+  options?: Partial<CrafterConfig & ParseDescriptorOptions>
 ): Observable<ContentInstance> {
   let pdo = mixParseDescriptorOptions({ parseFieldValueTypes: true, ...options });
   return urlTransform('renderUrlToStoreUrl', webUrl).pipe(
-    switchMap((path) => getDescriptor(path as string, { flatten: true, ...options })),
-    map((descriptor) => parseDescriptor(descriptor, pdo))
+    switchMap((path) => getItem(path as string, { flatten: true, ...options })),
+    map(({ descriptorDom }) => parseDescriptor(descriptorDom, pdo))
   );
 }
 
 /**
- * Inspects the data for getItem or getDescriptor responses and returns the inner content object
+ * Inspects the data for getItem responses and returns the inner content object
  */
 export function extractContent(data: Descriptor | Item) {
   let output = data;
@@ -265,13 +268,7 @@ export function extractChildren(children: Array<ItemWithChildren>) {
   });
 }
 
-const propsToRemove = [
-  'rootId',
-  'crafterSite',
-  'crafterPublishedDate',
-  'crafterPublishedDate_dt',
-  'inheritsFrom_smv'
-];
+const propsToRemove = ['rootId', 'crafterSite', 'crafterPublishedDate', 'crafterPublishedDate_dt', 'inheritsFrom_smv'];
 export function preParseSearchResults<T extends object = {}>(source: T): ContentInstance {
   Object.entries(source).forEach(([prop, value]) => {
     if (propsToRemove.includes(prop)) {

--- a/js-sdk/packages/content/test/index.spec.ts
+++ b/js-sdk/packages/content/test/index.spec.ts
@@ -19,7 +19,10 @@ import {
   NavigationService,
   UrlTransformationService,
   parseDescriptor,
-  extractContent, parseProps, parseFieldValue, preParseSearchResults
+  extractContent,
+  parseProps,
+  parseFieldValue,
+  preParseSearchResults
 } from '@craftercms/content';
 import { crafterConf } from '@craftercms/classes';
 import 'url-search-params-polyfill';
@@ -29,8 +32,8 @@ import * as nock from 'nock';
 
 // https://github.com/nock/nock/issues/2397
 import fetch, { Headers, Request, Response } from 'node-fetch';
-import {item2, parsedItem, parsedSearchHit, unparsedSearchHit} from "../../../util/mock-responses-common";
-import {ContentInstance} from "../../../dist/packages/models";
+import { item2, parsedItem, parsedSearchHit, unparsedSearchHit } from '../../../util/mock-responses-common';
+import { ContentInstance } from '../../../dist/packages/models';
 
 if (!globalThis.fetch) {
   (globalThis as any).fetch = fetch;
@@ -64,7 +67,8 @@ describe('Engine Client', () => {
           .get(endpoints.GET_ITEM_URL)
           .query({
             crafterSite,
-            url: '/site/website/index.xml'
+            url: '/site/website/index.xml',
+            flatten: false
           })
           .reply(200, item);
 
@@ -81,28 +85,6 @@ describe('Engine Client', () => {
       });
     });
 
-    describe('getDescriptor', () => {
-      // Tests the contentStore getDescriptor method. Checks that it returns the index descriptor of the site editorial.
-      it('return the index descriptor', (done) => {
-        nock(baseUrl)
-          .get(endpoints.GET_DESCRIPTOR)
-          .query({
-            crafterSite,
-            flatten: false,
-            url: '/site/website/index.xml'
-          })
-          .reply(200, descriptor);
-
-        ContentStoreService.getDescriptor('/site/website/index.xml').subscribe(
-          (respDescriptor) => {
-            expect(respDescriptor).to.not.be.null;
-            expect(respDescriptor.page.objectId).to.equal(descriptor.page.objectId);
-            done();
-          }
-        );
-      });
-    });
-
     describe('getChildren', () => {
       // Tests the contentStore getChildren method. Checks that it returns the children of the index page of the site editorial.
       // The children length at its ids should match the expected values.
@@ -111,15 +93,28 @@ describe('Engine Client', () => {
           .get(endpoints.GET_CHILDREN)
           .query({
             crafterSite,
-            url: '/site/website/'
+            url: '/site/website/',
+            flatten: false
           })
           .reply(200, children);
 
         ContentStoreService.getChildren('/site/website/').subscribe((respChildren) => {
-          const childrenNames = ['articles', 'crafter-level-descriptor.level.xml', 'entertainment', 'health', 'index.xml', 'search-results', 'style', 'technology'];
+          const childrenNames = [
+            'articles',
+            'crafter-level-descriptor.level.xml',
+            'entertainment',
+            'health',
+            'index.xml',
+            'search-results',
+            'style',
+            'technology'
+          ];
           const allChildrenExist = childrenNames.every((name) => respChildren.find((child) => child.name === name));
           expect(respChildren, `index should have ${children.length} child pages`).to.have.lengthOf(children.length);
-          expect(allChildrenExist, 'all children from getChildren response should match the expected children from mock response').to.be.true;
+          expect(
+            allChildrenExist,
+            'all children from getChildren response should match the expected children from mock response'
+          ).to.be.true;
           done();
         });
       });
@@ -133,7 +128,8 @@ describe('Engine Client', () => {
           .query({
             crafterSite,
             depth: 3,
-            url: '/site/website/articles/2021'
+            url: '/site/website/articles/2021',
+            flatten: false
           })
           .reply(200, tree);
 
@@ -185,20 +181,19 @@ describe('Engine Client', () => {
           })
           .reply(200, navBreadcrumb);
 
-        NavigationService.getNavBreadcrumb('/site/website/style/index.xml').subscribe(
-          (respNavBreadcrumb) => {
-            expect(respNavBreadcrumb, `breadcrumb should have ${navBreadcrumb.length} items`).to.have.lengthOf(
-              navBreadcrumb.length
-            );
-            expect(respNavBreadcrumb[0].label, `first item should be ${navBreadcrumb[0].label}`).to.equal(
-              navBreadcrumb[0].label
-            );
-            expect(respNavBreadcrumb[respNavBreadcrumb.length - 1].label, `last item should be ${navBreadcrumb[navBreadcrumb.length - 1].label}`).to.equal(
-              navBreadcrumb[navBreadcrumb.length - 1].label
-            );
-            done();
-          }
-        );
+        NavigationService.getNavBreadcrumb('/site/website/style/index.xml').subscribe((respNavBreadcrumb) => {
+          expect(respNavBreadcrumb, `breadcrumb should have ${navBreadcrumb.length} items`).to.have.lengthOf(
+            navBreadcrumb.length
+          );
+          expect(respNavBreadcrumb[0].label, `first item should be ${navBreadcrumb[0].label}`).to.equal(
+            navBreadcrumb[0].label
+          );
+          expect(
+            respNavBreadcrumb[respNavBreadcrumb.length - 1].label,
+            `last item should be ${navBreadcrumb[navBreadcrumb.length - 1].label}`
+          ).to.equal(navBreadcrumb[navBreadcrumb.length - 1].label);
+          done();
+        });
       });
     });
   });
@@ -217,10 +212,7 @@ describe('Engine Client', () => {
           })
           .reply(200, `"${renderUrl}"`);
 
-        UrlTransformationService.transform(
-          'storeUrlToRenderUrl',
-          '/site/website/style/index.xml'
-        ).subscribe((url) => {
+        UrlTransformationService.transform('storeUrlToRenderUrl', '/site/website/style/index.xml').subscribe((url) => {
           expect(url).to.equal(renderUrl);
           done();
         });
@@ -238,12 +230,10 @@ describe('Engine Client', () => {
           })
           .reply(200, `"${storeUrl}"`);
 
-        UrlTransformationService.transform('renderUrlToStoreUrl', '/technology').subscribe(
-          (url) => {
-            expect(url).to.equal(storeUrl);
-            done();
-          }
-        );
+        UrlTransformationService.transform('renderUrlToStoreUrl', '/technology').subscribe((url) => {
+          expect(url).to.equal(storeUrl);
+          done();
+        });
       });
     });
   });
@@ -266,7 +256,7 @@ describe('Object Utils', () => {
         ignoredProps: ['hero_image'],
         systemProps: ['internal-name', 'disabled', 'objectId']
       });
-      expect(parsedDescriptorWOptions.selected_b).to.equal("true");
+      expect(parsedDescriptorWOptions.selected_b).to.equal('true');
       // @ts-ignore - systemProp 'label' has been changed to 'itemName'
       expect(parsedDescriptorWOptions.craftercms.itemName).to.equal(parsedItem.craftercms.label);
       // 'hero_image' was set to be ignored in the options
@@ -289,7 +279,7 @@ describe('Object Utils', () => {
           disabled: false
         }
       };
-      const parsedProps = parseProps(descriptor.page, parsed,{ parseFieldValueTypes: true });
+      const parsedProps = parseProps(descriptor.page, parsed, { parseFieldValueTypes: true });
       expect(parsedProps).to.not.be.null;
       expect(parsedProps.selected_b).to.equal(true);
       expect(parsedProps.craftercms.label).to.equal(parsedItem.craftercms.label);
@@ -300,7 +290,7 @@ describe('Object Utils', () => {
         parseFieldValueTypes: false,
         systemPropMap: { 'internal-name': 'itemName' }
       });
-      expect(parsedPropsWOptions.selected_b).to.equal("true");
+      expect(parsedPropsWOptions.selected_b).to.equal('true');
       // @ts-ignore - systemProp 'label' has been changed to 'itemName'
       expect(parsedPropsWOptions.craftercms.itemName).to.equal(parsedItem.craftercms.label);
     });

--- a/js-sdk/packages/ice/package.json
+++ b/js-sdk/packages/ice/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@craftercms/ice",
-  "version": "0.0.0-PLACEHOLDER",
+  "version": "4.3.0",
   "description": "Crafter CMS in-context editing library",
   "main": "./bundles/ice.umd.js",
   "module": "./esm5/ice.js",

--- a/js-sdk/packages/models/package.json
+++ b/js-sdk/packages/models/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@craftercms/models",
-  "version": "0.0.0-PLACEHOLDER",
+  "version": "4.3.1",
   "description": "Crafter CMS data model definitions",
   "main": "./bundles/models.umd.js",
   "module": "./esm5/models.js",

--- a/js-sdk/packages/models/src/CrafterConfig.ts
+++ b/js-sdk/packages/models/src/CrafterConfig.ts
@@ -28,6 +28,7 @@ export interface CrafterConfig {
   contentTypeRegistry?: LookupTable;
   // TODO: Remove this in favour of fetchConfig.headers? Most make all sdk service use fetch.
   headers: LookupTable;
+  flatten: boolean;
 }
 
 export interface Endpoints {

--- a/js-sdk/packages/redux/README.md
+++ b/js-sdk/packages/redux/README.md
@@ -15,29 +15,30 @@ All of Crafter CMS packages can be used either via npm or in plain html/javascri
 - Import and use the redux store provided by the library, or implement your own store.
 - Import and use the action(s) you need.
 
-The examples below assume usage in the style of using via npm. If you're using the bundles, 
+The examples below assume usage in the style of using via npm. If you're using the bundles,
 directly importing as a script in the browser, these functions will be under the global variable
 named `craftercms.redux` (i.e. `window.craftercms.redux`).
 
 ## Utilities
 
 ### createReduxStore
+
 Creates a redux store with all the crafter-redux details attached. Optionally, custom app reducers and/or epics may be supplied to create the store as required by client application.
 
 `createReduxStore(config: Object)`
 
-| Parameters    |                |
-| ------------- |:--------------:|
-| config        | Configuration for the redux store |
+| Parameters |                                   |
+| ---------- | :-------------------------------: |
+| config     | Configuration for the redux store |
 
 Default config:
 
 ```json
-  {
-    namespace: 'craftercms',
-    reduxDevTools: true,
-    namespaceCrafterState: false
-  }
+{
+  "namespace": "craftercms",
+  "reduxDevTools": true,
+  "namespaceCrafterState": false
+}
 ```
 
 #### Example
@@ -45,150 +46,133 @@ Default config:
 - Set the configuration for the redux store
 
 ```typescript
-  import { crafterConf } from '@craftercms/classes';
+import { crafterConf } from '@craftercms/classes';
 
-  // This configuration will by used for all of the calls in the library. 
-  crafterConf.configure({
-    baseUrl: 'http://localhost:8090',  // By default - http://localhost:8080
-    site: 'editorial'
-  })
+// This configuration will by used for all of the calls in the library.
+crafterConf.configure({
+  baseUrl: 'http://localhost:8090', // By default - http://localhost:8080
+  site: 'editorial'
+});
 ```
 
 - Create redux store provided by the library
 
 ```typescript
-  import { createReduxStore } from '@craftercms/redux';
+import { createReduxStore } from '@craftercms/redux';
 
-  import { allReducers } from './your-reducers/reducers';
-  import thunk from 'redux-thunk';  // Or your chosen middleware
+import { allReducers } from './your-reducers/reducers';
+import thunk from 'redux-thunk'; // Or your chosen middleware
 
-  const store = createReduxStore({
-    namespaceCrafterState: true,   // Set to true to namespace craftercms states
-    namespace: "craftercms",       // Namespace label used for craftercms states
-    reducerMixin: allReducers,     // Your reducers (to combine them with the redux store)
-    reduxDevTools: true,           // Set to true if you want to use reduxDevTools extension
-    additionalMiddleWare: [thunk]  // Your chosen middleware to combine it with the library store
-  });
-
+const store = createReduxStore({
+  namespaceCrafterState: true, // Set to true to namespace craftercms states
+  namespace: 'craftercms', // Namespace label used for craftercms states
+  reducerMixin: allReducers, // Your reducers (to combine them with the redux store)
+  reduxDevTools: true, // Set to true if you want to use reduxDevTools extension
+  additionalMiddleWare: [thunk] // Your chosen middleware to combine it with the library store
+});
 ```
 
 ### getState
+
 Retrieves the current redux store state.
 
 `getState(store: Store)`
 
-| Parameters    |                |
-| ------------- |:--------------:|
-| store           | Redux store where the state is going to be retrieved from |
+| Parameters |                                                           |
+| ---------- | :-------------------------------------------------------: |
+| store      | Redux store where the state is going to be retrieved from |
 
 #### Example
 
 ```typescript
-  import { getState } from '@craftercms/redux';
+import { getState } from '@craftercms/redux';
 
-  // store = Redux store created in previous example
+// store = Redux store created in previous example
 
-  const state = getState(store);
-
+const state = getState(store);
 ```
 
 ## Action Creators
 
 ### getItem
+
 Creates an action to get an Item from the content store.
 
 `getItem(itemUrl: string)`
 
-| Parameters    |                |
-| ------------- |:--------------:|
-| 
-path           | The item’s path in the content store |
+| Parameters |     |
+| ---------- | :-: |
+
+|
+path | The item’s path in the content store |
 
 #### Example
 
 - Dispatch action to get the index page from the site into your store
 
 ```typescript
-  import { getItem } from '@craftercms/redux';
+import { getItem } from '@craftercms/redux';
 
-  const itemUrl = '/site/website/index.xml';
+const itemUrl = '/site/website/index.xml';
 
-  store.dispatch(getItem(itemUrl));
-```
-
-### getDescriptor
-Creates an action to get the descriptor data of an Item in the content store.
-
-`getDescriptor(path: string)`
-
-| Parameters    |                |
-| ------------- |:--------------:|
-| path           | The item’s path in the content store |
-
-#### Example
-
-- Dispatch action to get the index page descriptor from the site into your store
-
-```typescript
-  import { getDescriptor } from '@craftercms/redux';
-
-  const itemUrl = '/site/website/index.xml';
-
-  store.dispatch(getDescriptor(itemUrl));
+store.dispatch(getItem(itemUrl));
 ```
 
 ### getChildren
+
 Creates an action to get the list of Items directly under a folder into your store.
 
 `getChildren(path: string)`
 
-| Parameters    |                |
-| ------------- |:--------------:|
-| path           | The folder’s path |
+| Parameters |                   |
+| ---------- | :---------------: |
+| path       | The folder’s path |
 
 #### Example
 
 - Dispatch action to get the children under a folder into your store
 
 ```typescript
-  import { getChildren } from '@craftercms/redux';
+import { getChildren } from '@craftercms/redux';
 
-  const path = '/site/website';
+const path = '/site/website';
 
-  store.dispatch(getChildren(path));
+store.dispatch(getChildren(path));
 ```
 
 ### getTree
+
 Creates an action to get the complete Item hierarchy under the specified folder in the content store.
 
 `getTree({ path: string, depth: int })`
 
-| Parameters    |                |
-| ------------- |:--------------:|
-| path           | The folder’s path |
-| depth         | Amount of levels to include. Optional. Default is `1` |
+| Parameters |                                                       |
+| ---------- | :---------------------------------------------------: |
+| path       |                   The folder’s path                   |
+| depth      | Amount of levels to include. Optional. Default is `1` |
 
 #### Example
 
 - Dispatch action to get the items tree under the root folder into your store
 
 ```typescript
-  import { getTree } from '@craftercms/redux';
+import { getTree } from '@craftercms/redux';
 
-  const path = '/site/website';
+const path = '/site/website';
 
-  store.dispatch(getTree({ path, depth: 2 }));
+store.dispatch(getTree({ path, depth: 2 }));
 ```
 
 ### getNav
+
 Creates an action to return the navigation tree with the specified depth for the specified store URL.
 
 `getNav({ path: string, depth: int, currentPageUrl: string })`
 
-| Parameters     |                |
-| -------------- |:--------------:|
-| path            | The folder’s path |
-| depth          | Amount of levels to include. Optional. Default is `1` |
+| Parameters     |                                                        |
+| -------------- | :----------------------------------------------------: |
+| path           |                   The folder’s path                    |
+| depth          | Amount of levels to include. Optional. Default is `1`  |
 | currentPageUrl | The URL of the current page. Optional. Default is `''` |
 
 #### Example
@@ -196,57 +180,59 @@ Creates an action to return the navigation tree with the specified depth for the
 - Dispatch action to get the navigation tree of the root folder from the site (depth = 2)
 
 ```typescript
-  import { getNav } from '@craftercms/redux';
+import { getNav } from '@craftercms/redux';
 
-  const path = '/site/website';
+const path = '/site/website';
 
-  store.dispatch(getNav({ path, depth: 2 }));
+store.dispatch(getNav({ path, depth: 2 }));
 ```
 
 ### getNavBreadcrumb
+
 Creates an action to return the navigation items that form the breadcrumb for the specified store URL.
 
 `getNavBreadcrumb({ path: string, root: string })`
 
-| Parameters     |                |
-| -------------- |:--------------:|
-| path            | The folder’s path |
-| root           | the root URL, basically the starting point of the breadcrumb. Optional. Default is `''` |
+| Parameters |                                                                                         |
+| ---------- | :-------------------------------------------------------------------------------------: |
+| path       |                                    The folder’s path                                    |
+| root       | the root URL, basically the starting point of the breadcrumb. Optional. Default is `''` |
 
 #### Example
 
 - Dispatch action to get the breadcrumb for the root folder from the site
 
 ```typescript
-  import { getNavBreadcrumb } from '@craftercms/redux';
+import { getNavBreadcrumb } from '@craftercms/redux';
 
-  const path = '/site/website/health';
+const path = '/site/website/health';
 
-  store.dispatch(getNavBreadcrumb({ path }));
+store.dispatch(getNavBreadcrumb({ path }));
 ```
 
 ### search
+
 Creates an action to return the result for a given query.
 
-`search(query: Query)` 
+`search(query: Query)`
 
-| Parameters    |                |
-| ------------- |:--------------:|
-| query         | The query object |
+| Parameters |                  |
+| ---------- | :--------------: |
+| query      | The query object |
 
 #### Example
 
 - Dispatch action to query for content
 
 ```typescript
-  import { SearchService } from '@craftercms/search';
-  import { search } from '@craftercms/redux';
+import { SearchService } from '@craftercms/search';
+import { search } from '@craftercms/redux';
 
-  const query = SearchService.createQuery();
-  query.query = "*:*";
-  query.filterQueries = ['content-type:"/component/video"'];
+const query = SearchService.createQuery();
+query.query = '*:*';
+query.filterQueries = ['content-type:"/component/video"'];
 
-  store.dispatch(search(query));
+store.dispatch(search(query));
 ```
 
 Store state while loading item
@@ -286,11 +272,11 @@ Resulting store state
 - Get the tree under a specified folder from the site into your store
 
 ```typescript
-  import { getTree } from '@craftercms/redux';
+import { getTree } from '@craftercms/redux';
 
-  const path = '/site/website';
+const path = '/site/website';
 
-  store.dispatch(getTree({ path }));
+store.dispatch(getTree({ path }));
 ```
 
 Store state while loading tree

--- a/js-sdk/packages/redux/package.json
+++ b/js-sdk/packages/redux/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@craftercms/redux",
-  "version": "0.0.0-PLACEHOLDER",
+  "version": "5.0.0",
   "description": "Crafter CMS bindings for Redux",
   "main": "./bundles/redux.umd.js",
   "module": "./esm5/redux.js",
@@ -26,7 +26,7 @@
     "test": "mocha"
   },
   "dependencies": {
-    "@craftercms/content": "0.0.0-PLACEHOLDER",
+    "@craftercms/content": "5.0.0",
     "@reduxjs/toolkit": "^2.2.2",
     "redux": "^5.0.1",
     "redux-observable": "^3.0.0-rc.2",

--- a/js-sdk/packages/redux/src/actions/content.ts
+++ b/js-sdk/packages/redux/src/actions/content.ts
@@ -14,25 +14,23 @@
  * along with this program. If not, see http://www.gnu.org/licenses/.
  */
 
-import { Descriptor, Item, NavigationItem } from '@craftercms/models';
-import { createAction } from "@reduxjs/toolkit";
-import { internal_getNav, internal_getNavBreadcrumb } from "./content_internal";
+import { CrafterConfig, Item, NavigationItem } from '@craftercms/models';
+import { createAction } from '@reduxjs/toolkit';
+import { internal_getNav, internal_getNavBreadcrumb } from './content_internal';
 
-export const getItem = /*#__PURE__*/ createAction<string>('GET_ITEM');
+export const getItem = /*#__PURE__*/ createAction<{ url: string; config?: CrafterConfig }>('GET_ITEM');
 
-export const getItemComplete = /*#__PURE__*/ createAction<{ url: string, item?: Item }>('GET_ITEM_COMPLETE');
-
-export const getDescriptor = /*#__PURE__*/ createAction<string>('GET_DESCRIPTOR');
-
-export const getDescriptorComplete = /*#__PURE__*/ createAction<{ url: string, descriptor?: Descriptor }>('GET_DESCRIPTOR_COMPLETE');
+export const getItemComplete = /*#__PURE__*/ createAction<{ url: string; item?: Item }>('GET_ITEM_COMPLETE');
 
 export const getChildren = /*#__PURE__*/ createAction<string>('GET_CHILDREN');
 
-export const getChildrenComplete = /*#__PURE__*/ createAction<{ url: string, children?: Array<Item> }>('GET_CHILDREN_COMPLETE');
+export const getChildrenComplete = /*#__PURE__*/ createAction<{ url: string; children?: Array<Item> }>(
+  'GET_CHILDREN_COMPLETE'
+);
 
-export const getTree = /*#__PURE__*/ createAction<{ url: string, depth?: Number }>('GET_TREE');
+export const getTree = /*#__PURE__*/ createAction<{ url: string; depth?: Number }>('GET_TREE');
 
-export const getTreeComplete = /*#__PURE__*/ createAction<{ url: string, tree?: Item }>('GET_TREE_COMPLETE');
+export const getTreeComplete = /*#__PURE__*/ createAction<{ url: string; tree?: Item }>('GET_TREE_COMPLETE');
 
 interface GetNavAction {
   type: string;
@@ -40,36 +38,45 @@ interface GetNavAction {
     url: string;
     depth?: Number;
     currentPageUrl?: string;
-  }
+  };
 }
 
 export function getNav(url: string): GetNavAction;
 export function getNav(url: string, depth: Number): GetNavAction;
 export function getNav(url: string, depth: Number, currentPageUrl: string): GetNavAction;
 export function getNav(payload: { url: string; depth?: Number; currentPageUrl?: string }): GetNavAction;
-export function getNav(payloadOrUrl: string | { url: string; depth?: Number; currentPageUrl?: string }, depth: Number = 1, currentPageUrl: string = ''): GetNavAction {
+export function getNav(
+  payloadOrUrl: string | { url: string; depth?: Number; currentPageUrl?: string },
+  depth: Number = 1,
+  currentPageUrl: string = ''
+): GetNavAction {
   if (typeof payloadOrUrl === 'string') {
-    console.warn('Warning: This signature is deprecated, adjust to use the object signature instead ({ url, depth?, currentPageUrl? }).');
+    console.warn(
+      'Warning: This signature is deprecated, adjust to use the object signature instead ({ url, depth?, currentPageUrl? }).'
+    );
     return internal_getNav({ url: payloadOrUrl, depth, currentPageUrl });
   } else {
     return internal_getNav(payloadOrUrl);
   }
 }
 
-export const getNavComplete = /*#__PURE__*/ createAction<{ url: string, nav?: NavigationItem }>('GET_NAV_COMPLETE');
+export const getNavComplete = /*#__PURE__*/ createAction<{ url: string; nav?: NavigationItem }>('GET_NAV_COMPLETE');
 
 export interface GetNavBreadcrumbAction {
   type: string;
   payload: {
     url: string;
     root?: string;
-  }
+  };
 }
 
 export function getNavBreadcrumb(url: string): GetNavBreadcrumbAction;
 export function getNavBreadcrumb(url: string, root: string): GetNavBreadcrumbAction;
-export function getNavBreadcrumb(payload: { url: string, root?: string }): GetNavBreadcrumbAction;
-export function getNavBreadcrumb(payloadOrUrl: string | { url: string, root?: string }, root: string = ''): GetNavBreadcrumbAction {
+export function getNavBreadcrumb(payload: { url: string; root?: string }): GetNavBreadcrumbAction;
+export function getNavBreadcrumb(
+  payloadOrUrl: string | { url: string; root?: string },
+  root: string = ''
+): GetNavBreadcrumbAction {
   if (typeof payloadOrUrl === 'string') {
     console.warn('Warning: This signature is deprecated, adjust to use the object signature instead ({ url, root? }).');
     return internal_getNavBreadcrumb({ url: payloadOrUrl, root });
@@ -78,4 +85,6 @@ export function getNavBreadcrumb(payloadOrUrl: string | { url: string, root?: st
   }
 }
 
-export const getNavBreadcrumbComplete = /*#__PURE__*/ createAction<{ url: string, breadcrumb?: Array<NavigationItem> }>('GET_NAV_BREADCRUMB_COMPLETE');
+export const getNavBreadcrumbComplete = /*#__PURE__*/ createAction<{ url: string; breadcrumb?: Array<NavigationItem> }>(
+  'GET_NAV_BREADCRUMB_COMPLETE'
+);

--- a/js-sdk/packages/redux/src/actions/search.ts
+++ b/js-sdk/packages/redux/src/actions/search.ts
@@ -15,10 +15,10 @@
  */
 
 import { Query } from '@craftercms/search';
-import { createAction } from "@reduxjs/toolkit";
+import { createAction } from '@reduxjs/toolkit';
 
 export const SEARCH_COMPLETE = 'CRAFTERCMS_SEARCH_COMPLETE';
 
-export const search = /*#__PURE__*/ createAction<Query>('GET_ITEM');
+export const search = /*#__PURE__*/ createAction<Query>('CRAFTERCMS_SEARCH');
 
-export const searchComplete = /*#__PURE__*/ createAction<{ queryId: string, response? }>(SEARCH_COMPLETE);
+export const searchComplete = /*#__PURE__*/ createAction<{ queryId: string; response? }>(SEARCH_COMPLETE);

--- a/js-sdk/packages/redux/src/epics/content.ts
+++ b/js-sdk/packages/redux/src/epics/content.ts
@@ -23,8 +23,6 @@ import { ContentStoreService, NavigationService } from '@craftercms/content';
 import {
   getItem,
   getItemComplete,
-  getDescriptor,
-  getDescriptorComplete,
   getChildren,
   getChildrenComplete,
   getTree,
@@ -32,111 +30,117 @@ import {
   getNavComplete,
   getNavBreadcrumbComplete
 } from '../actions/content';
-import { Item, NavigationItem } from "@craftercms/models";
-import { internal_getNav, internal_getNavBreadcrumb } from "../actions/content_internal";
+import { Item, NavigationItem } from '@craftercms/models';
+import { internal_getNav, internal_getNavBreadcrumb } from '../actions/content_internal';
 
-export const getItemEpic =
-  (action$: Observable<AnyAction>) => action$.pipe(
+export const getItemEpic = (action$: Observable<AnyAction>) =>
+  action$.pipe(
     ofType(getItem.type),
     mergeMap(({ payload }) =>
-      ContentStoreService.getItem(payload)
-        .pipe(
-          map((item: Item) => getItemComplete({
+      ContentStoreService.getItem(payload.url, payload.config).pipe(
+        map((item: Item) =>
+          getItemComplete({
             item,
+            url: payload.url
+          })
+        ),
+        catchError(() =>
+          of(
+            getItemComplete({
+              url: payload.url
+            })
+          )
+        )
+      )
+    )
+  );
+
+export const getChildrenEpic = (action$: Observable<AnyAction>) =>
+  action$.pipe(
+    ofType(getChildren.type),
+    mergeMap(({ payload }) =>
+      ContentStoreService.getChildren(payload).pipe(
+        map((children: Item[]) =>
+          getChildrenComplete({
+            children,
             url: payload
-          })),
-          catchError(() => of(getItemComplete({
-            url: payload
-          })))
-        ))
+          })
+        ),
+        catchError(() =>
+          of(
+            getChildrenComplete({
+              url: payload
+            })
+          )
+        )
+      )
+    )
   );
 
-export const getDescriptorEpic =
-  (action$: Observable<AnyAction>) => action$.pipe(
-      ofType(getDescriptor.type),
-      mergeMap(({ payload }) =>
-        ContentStoreService.getDescriptor(payload)
-          .pipe(
-              map(descriptor => getDescriptorComplete({
-                descriptor,
-                url: payload
-              })),
-              catchError(() => of(getDescriptorComplete({
-                url: payload
-              })))
-          ))
-
+export const getTreeEpic = (action$: Observable<AnyAction>) =>
+  action$.pipe(
+    ofType(getTree.type),
+    mergeMap(({ payload }) =>
+      ContentStoreService.getTree(payload.url, payload.depth).pipe(
+        map((tree: Item) =>
+          getTreeComplete({
+            tree,
+            url: payload.url
+          })
+        ),
+        catchError(() =>
+          of(
+            getTreeComplete({
+              url: payload.url
+            })
+          )
+        )
+      )
+    )
   );
 
-export const getChildrenEpic =
-  (action$: Observable<AnyAction>) => action$.pipe(
-      ofType(getChildren.type),
-      mergeMap(({ payload }) =>
-      ContentStoreService.getChildren(payload)
-          .pipe(
-              map((children: Item[]) => getChildrenComplete({
-                children,
-                url: payload
-              })),
-              catchError(() => of(getChildrenComplete({
-                url: payload
-              })))
-          ))
+export const getNavEpic = (action$: Observable<AnyAction>) =>
+  action$.pipe(
+    ofType(internal_getNav.type),
+    mergeMap(({ payload }) =>
+      NavigationService.getNavTree(payload.url, payload.depth, payload.currentPageUrl).pipe(
+        map((nav: NavigationItem) =>
+          getNavComplete({
+            nav,
+            url: payload.url
+          })
+        ),
+        catchError(() =>
+          of(
+            getNavComplete({
+              url: payload.url
+            })
+          )
+        )
+      )
+    )
   );
 
-export const getTreeEpic =
-  (action$: Observable<AnyAction>) => action$.pipe(
-      ofType(getTree.type),
-      mergeMap(({ payload }) =>
-      ContentStoreService.getTree(payload.url, payload.depth)
-          .pipe(
-              map((tree: Item) => getTreeComplete({
-                tree,
-                url: payload.url
-              })),
-              catchError(() => of(getTreeComplete({
-                url: payload.url
-              })))
-          ))
+export const getNavBreadcrumbEpic = (action$: Observable<AnyAction>) =>
+  action$.pipe(
+    ofType(internal_getNavBreadcrumb.type),
+    mergeMap(({ payload }) =>
+      NavigationService.getNavBreadcrumb(payload.url, payload.root).pipe(
+        map((breadcrumb: NavigationItem[]) =>
+          getNavBreadcrumbComplete({
+            breadcrumb,
+            url: payload.url
+          })
+        ),
+        catchError(() =>
+          of(
+            getNavBreadcrumbComplete({
+              url: payload.url
+            })
+          )
+        )
+      )
+    )
   );
 
-export const getNavEpic =
-  (action$: Observable<AnyAction>) => action$.pipe(
-      ofType(internal_getNav.type),
-      mergeMap(({ payload }) =>
-      NavigationService.getNavTree(payload.url, payload.depth, payload.currentPageUrl)
-          .pipe(
-              map((nav: NavigationItem) => getNavComplete({
-                nav,
-                url: payload.url
-              })),
-              catchError(() => of(getNavComplete({
-                url: payload.url
-              })))
-          ))
-  );
-
-export const getNavBreadcrumbEpic =
-  (action$: Observable<AnyAction>) => action$.pipe(
-      ofType(internal_getNavBreadcrumb.type),
-      mergeMap(({ payload }) =>
-      NavigationService.getNavBreadcrumb(payload.url, payload.root)
-          .pipe(
-              map((breadcrumb: NavigationItem[]) => getNavBreadcrumbComplete({
-                breadcrumb,
-                url: payload.url
-              })),
-              catchError(() => of(getNavBreadcrumbComplete({
-                url: payload.url
-              })))
-          ))
-  );
-
-  export const allContentEpics = [
-    getItemEpic,
-    getDescriptorEpic,
-    getChildrenEpic,
-    getTreeEpic,
-    getNavEpic,
-    getNavBreadcrumbEpic
-  ];
+export const allContentEpics = [getItemEpic, getChildrenEpic, getTreeEpic, getNavEpic, getNavBreadcrumbEpic];

--- a/js-sdk/packages/redux/src/reducers/content.ts
+++ b/js-sdk/packages/redux/src/reducers/content.ts
@@ -20,8 +20,6 @@ import { flattenEntries } from '../utils';
 import {
   getItem,
   getItemComplete,
-  getDescriptor,
-  getDescriptorComplete,
   getChildren,
   getChildrenComplete,
   getTree,
@@ -30,21 +28,24 @@ import {
   getNavBreadcrumbComplete
 } from '../actions/content';
 import { StateContainer, Item } from '@craftercms/models';
-import { internal_getNav, internal_getNavBreadcrumb } from "../actions/content_internal";
+import { internal_getNav, internal_getNavBreadcrumb } from '../actions/content_internal';
 
-export function itemsReducer(state = {
-  loading: {}, // { all: boolean, [id: string]: boolean }
-  entries: {}
-}, action: AnyAction): StateContainer<Item> {
+export function itemsReducer(
+  state = {
+    loading: {}, // { all: boolean, [id: string]: boolean }
+    entries: {}
+  },
+  action: AnyAction
+): StateContainer<Item> {
   switch (action.type) {
     case getItem.type: {
       return {
         ...state,
         loading: {
           ...state.loading,
-          [action.payload]: true
+          [action.payload.url]: true
         }
-      }
+      };
     }
     case getItemComplete.type: {
       const { item, url } = action.payload;
@@ -58,50 +59,20 @@ export function itemsReducer(state = {
           ...state.entries,
           [url]: item
         }
-      }
+      };
     }
     default:
-      return state
+      return state;
   }
 }
 
-export function descriptorsReducer(state = {
-  loading: {}, // { all: boolean, [id: string]: boolean }
-  entries: {}
-}, action: AnyAction): StateContainer<Item> {
-  switch (action.type) {
-    case getDescriptor.type: {
-      return {
-        ...state,
-        loading: {
-          ...state.loading,
-          [action.payload]: true
-        }
-      }
-    }
-    case getDescriptorComplete.type: {
-      const { descriptor, url } = action.payload;
-      return {
-        ...state,
-        loading: {
-          ...state.loading,
-          [url]: false
-        },
-        entries: {
-          ...state.entries,
-          [url]: descriptor
-        }
-      }
-    }
-    default:
-      return state
-  }
-}
-
-export function childrenReducer(state = {
-  loading: {}, // { all: boolean, [id: string]: boolean }
-  entries: {}
-}, action: AnyAction): StateContainer<Item> {
+export function childrenReducer(
+  state = {
+    loading: {}, // { all: boolean, [id: string]: boolean }
+    entries: {}
+  },
+  action: AnyAction
+): StateContainer<Item> {
   switch (action.type) {
     case getChildren.type: {
       const url = action.payload;
@@ -111,7 +82,7 @@ export function childrenReducer(state = {
           ...state.loading,
           [url]: true
         }
-      }
+      };
     }
     case getChildrenComplete.type: {
       const { children, url } = action.payload;
@@ -125,18 +96,21 @@ export function childrenReducer(state = {
           ...state.entries,
           [url]: children
         }
-      }
+      };
     }
     default:
-      return state
+      return state;
   }
 }
 
-export function treeReducer(state = {
-  loading: {}, // { all: boolean, [id: string]: boolean }
-  entries: {},
-  childIds: {}
-}, action: AnyAction): StateContainer<any> {
+export function treeReducer(
+  state = {
+    loading: {}, // { all: boolean, [id: string]: boolean }
+    entries: {},
+    childIds: {}
+  },
+  action: AnyAction
+): StateContainer<any> {
   switch (action.type) {
     case getTree.type: {
       const { url } = action.payload;
@@ -146,11 +120,11 @@ export function treeReducer(state = {
           ...state.loading,
           [url]: true
         }
-      }
+      };
     }
     case getTreeComplete.type: {
       const { tree, url } = action.payload;
-      const flatEntries = typeof(tree) === "undefined" ? null : flattenEntries(tree);
+      const flatEntries = typeof tree === 'undefined' ? null : flattenEntries(tree);
 
       return {
         ...state,
@@ -160,17 +134,20 @@ export function treeReducer(state = {
         },
         entries: flatEntries ? { ...state.entries, ...flatEntries.entries } : { ...state.entries },
         childIds: flatEntries ? { ...state.childIds, ...flatEntries.childIds } : { ...state.childIds }
-      }
+      };
     }
     default:
-      return state
+      return state;
   }
 }
 
-export function breadcrumbsReducer(state = {
-  loading: {}, // { all: boolean, [id: string]: boolean }
-  entries: {}
-}, action: AnyAction): StateContainer<Item> {
+export function breadcrumbsReducer(
+  state = {
+    loading: {}, // { all: boolean, [id: string]: boolean }
+    entries: {}
+  },
+  action: AnyAction
+): StateContainer<Item> {
   switch (action.type) {
     case internal_getNavBreadcrumb.type: {
       const { url } = action.payload;
@@ -181,7 +158,7 @@ export function breadcrumbsReducer(state = {
           ...state.loading,
           [url]: true
         }
-      }
+      };
     }
     case getNavBreadcrumbComplete.type: {
       const { breadcrumb, url } = action.payload;
@@ -195,18 +172,21 @@ export function breadcrumbsReducer(state = {
           ...state.entries,
           [url]: breadcrumb
         }
-      }
+      };
     }
     default:
-      return state
+      return state;
   }
 }
 
-export function navigationReducer(state = {
-  loading: {}, // { all: boolean, [id: string]: boolean }
-  entries: {},
-  childIds: {}
-}, action: AnyAction): StateContainer<any> {
+export function navigationReducer(
+  state = {
+    loading: {}, // { all: boolean, [id: string]: boolean }
+    entries: {},
+    childIds: {}
+  },
+  action: AnyAction
+): StateContainer<any> {
   switch (action.type) {
     case internal_getNav.type: {
       return {
@@ -215,11 +195,11 @@ export function navigationReducer(state = {
           ...state.loading,
           [action.payload.url]: true
         }
-      }
+      };
     }
     case getNavComplete.type: {
       const { nav, url } = action.payload;
-      const flatEntries = typeof(nav) === "undefined" ? null : flattenEntries(nav, 'subItems');
+      const flatEntries = typeof nav === 'undefined' ? null : flattenEntries(nav, 'subItems');
 
       return {
         ...state,
@@ -229,9 +209,9 @@ export function navigationReducer(state = {
         },
         entries: flatEntries ? { ...state.entries, ...flatEntries.entries } : { ...state.entries },
         childIds: flatEntries ? { ...state.childIds, ...flatEntries.childIds } : { ...state.childIds }
-      }
+      };
     }
     default:
-      return state
+      return state;
   }
 }

--- a/js-sdk/packages/redux/src/reducers/reducers.ts
+++ b/js-sdk/packages/redux/src/reducers/reducers.ts
@@ -14,19 +14,11 @@
  * along with this program. If not, see http://www.gnu.org/licenses/.
  */
 
-import {
-  itemsReducer,
-  navigationReducer,
-  breadcrumbsReducer,
-  descriptorsReducer,
-  childrenReducer,
-  treeReducer
-} from './content';
-import { searchReducer } from './search'
+import { itemsReducer, navigationReducer, breadcrumbsReducer, childrenReducer, treeReducer } from './content';
+import { searchReducer } from './search';
 
 export const allReducers = {
   items: itemsReducer,
-  descriptors: descriptorsReducer,
   children: childrenReducer,
   trees: treeReducer,
   navigation: navigationReducer,

--- a/js-sdk/packages/redux/test/index.spec.ts
+++ b/js-sdk/packages/redux/test/index.spec.ts
@@ -26,10 +26,6 @@ import {
   getItemComplete,
   itemsReducer,
   getItemEpic,
-  getDescriptor,
-  getDescriptorComplete,
-  descriptorsReducer,
-  getDescriptorEpic,
   getChildren,
   getChildrenComplete,
   childrenReducer,
@@ -90,9 +86,9 @@ describe('Crafter CMS Redux', () => {
         let url = '/site/website/index.xml',
           expectedAction = {
             type: 'GET_ITEM',
-            payload: url
+            payload: { url }
           };
-        const action = getItem(url);
+        const action = getItem({ url });
         expect(action).to.deep.equal(expectedAction);
         done();
       });
@@ -105,32 +101,6 @@ describe('Crafter CMS Redux', () => {
           payload: item
         };
         const action = getItemComplete(item);
-        expect(action).to.deep.equal(expectedAction);
-        done();
-      });
-    });
-
-    describe('getDescriptor Action', () => {
-      it('should return the expected GET_DESCRIPTOR action', (done) => {
-        let url = '/site/website/index.xml',
-          expectedAction = {
-            type: 'GET_DESCRIPTOR',
-            payload: url
-          };
-        const action = getDescriptor(url);
-        expect(action).to.deep.equal(expectedAction);
-        done();
-      });
-    });
-
-    describe('getDescriptorComplete Action', () => {
-      it('should return the expected GET_DESCRIPTOR_COMPLETE action', (done) => {
-        let url: '/site/website/index.xml',
-          expectedAction = {
-            type: 'GET_DESCRIPTOR_COMPLETE',
-            payload: { descriptor, url }
-          };
-        const action = getDescriptorComplete({ descriptor, url });
         expect(action).to.deep.equal(expectedAction);
         done();
       });
@@ -261,7 +231,7 @@ describe('Crafter CMS Redux', () => {
         let url = '/site/website/index.xml',
           action = {
             type: 'GET_ITEM',
-            payload: url
+            payload: { url }
           },
           expectedState = {
             loading: {
@@ -295,48 +265,6 @@ describe('Crafter CMS Redux', () => {
           };
 
         let newState = itemsReducer(undefined, action);
-        expect(newState).to.deep.equal(expectedState);
-        done();
-      });
-    });
-
-    describe('getDescriptor Reducer', () => {
-      it('should return the expected GET_DESCRIPTOR reducer', (done) => {
-        let url = '/site/website/index.xml',
-          action = {
-            type: 'GET_DESCRIPTOR',
-            payload: url
-          },
-          expectedState = {
-            loading: {
-              [url]: true
-            },
-            entries: {}
-          };
-
-        let newState = descriptorsReducer(undefined, action);
-        expect(newState).to.deep.equal(expectedState);
-        done();
-      });
-    });
-
-    describe('getDescriptorComplete Reducer', () => {
-      it('should return the expected GET_DESCRIPTOR_COMPLETE reducer', (done) => {
-        let url = '/site/website',
-          action = {
-            type: 'GET_DESCRIPTOR_COMPLETE',
-            payload: { descriptor, url }
-          },
-          expectedState = {
-            loading: {
-              [url]: false
-            },
-            entries: {
-              [url]: descriptor
-            }
-          };
-
-        let newState = descriptorsReducer(undefined, action);
         expect(newState).to.deep.equal(expectedState);
         done();
       });
@@ -530,14 +458,15 @@ describe('Crafter CMS Redux', () => {
           .get('/api/1/site/content_store/item.json')
           .query({
             crafterSite: 'editorial',
-            url: '/site/website/index.xml'
+            url: '/site/website/index.xml',
+            flatten: false
           })
           .reply(200, item);
 
         let url = '/site/website/index.xml',
           actionObs = of({
             type: 'GET_ITEM',
-            payload: url
+            payload: { url }
           }),
           expectedResponse = {
             payload: {
@@ -557,42 +486,14 @@ describe('Crafter CMS Redux', () => {
       });
     });
 
-    describe('getDescriptor Epic', () => {
-      it('should return the expected GET_DESCRIPTOR epic', (done) => {
-        nock('http://localhost:8080')
-          .get('/api/1/site/content_store/descriptor.json')
-          .query({
-            crafterSite: 'editorial',
-            flatten: false,
-            url: '/site/website/index.xml'
-          })
-          .reply(200, descriptor);
-
-        let url = '/site/website/index.xml',
-          actionObs = of({
-            type: 'GET_DESCRIPTOR',
-            payload: url
-          }),
-          expectedResponse = {
-            payload: { descriptor, url },
-            type: 'GET_DESCRIPTOR_COMPLETE'
-          };
-
-        getDescriptorEpic(actionObs).subscribe((response) => {
-          expect(response.type).to.equal(expectedResponse.type);
-          expect(response.payload.descriptor.page.objectId).to.equal(expectedResponse.payload.descriptor.page.objectId);
-          done();
-        });
-      });
-    });
-
     describe('getChildren Epic', () => {
       it('should return the expected GET_CHILDREN epic', (done) => {
         nock('http://localhost:8080')
           .get('/api/1/site/content_store/children.json')
           .query({
             crafterSite: 'editorial',
-            url: '/site/website'
+            url: '/site/website',
+            flatten: false
           })
           .reply(200, children);
 
@@ -620,7 +521,8 @@ describe('Crafter CMS Redux', () => {
           .query({
             crafterSite: 'editorial',
             depth: 1,
-            url: '/site/website'
+            url: '/site/website',
+            flatten: false
           })
           .reply(200, tree);
 

--- a/js-sdk/packages/search/package.json
+++ b/js-sdk/packages/search/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@craftercms/search",
-  "version": "0.0.0-PLACEHOLDER",
+  "version": "4.3.1",
   "description": "Crafter CMS search service and associated tools",
   "main": "./bundles/search.umd.js",
   "module": "./esm5/search.js",
@@ -26,9 +26,9 @@
     "test": "mocha"
   },
   "dependencies": {
-    "@craftercms/classes": "0.0.0-PLACEHOLDER",
-    "@craftercms/models": "0.0.0-PLACEHOLDER",
-    "@craftercms/utils": "0.0.0-PLACEHOLDER",
+    "@craftercms/classes": "4.4.1",
+    "@craftercms/models": "4.3.1",
+    "@craftercms/utils": "4.3.0",
     "rxjs": "^7.8.1",
     "uuid": "^10.0.0"
   },

--- a/js-sdk/packages/utils/package.json
+++ b/js-sdk/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@craftercms/utils",
-  "version": "0.0.0-PLACEHOLDER",
+  "version": "4.3.0",
   "description": "Crafter CMS utility and helper functions",
   "main": "./bundles/utils.umd.js",
   "module": "./esm5/utils.js",

--- a/studio-ui/ui/app/src/main.dev.tsx
+++ b/studio-ui/ui/app/src/main.dev.tsx
@@ -1,0 +1,178 @@
+import React, { useEffect, useState } from 'react';
+import { createRoot } from 'react-dom/client';
+import CrafterCMSNextBridge from './components/CrafterCMSNextBridge';
+import { useDispatch } from 'react-redux';
+import { useIntl } from 'react-intl';
+import useActiveSiteId from './hooks/useActiveSiteId';
+import BrowseFilesDialog from './components/BrowseFilesDialog';
+import { processPopulateExpression, validateDatePopulateExpression } from './components/FormsEngine/lib/controlHelpers';
+import TextField from '@mui/material/TextField';
+import Box from '@mui/material/Box';
+import Preview from './pages/Preview';
+import Global from './pages/Global';
+import { LoadingState } from './components';
+import { Skeleton } from '@mui/material';
+
+function App() {
+	const dispatch = useDispatch();
+	const { formatMessage } = useIntl();
+	const siteId = useActiveSiteId();
+	const [item, setItem] = useState(null);
+	const [exp, setExp] = useState('{now}');
+	const [processed, setProcessed] = useState(null);
+
+	useEffect(() => {
+		// showSingleFileUploadDialog({
+		// 	dispatch,
+		// 	siteId,
+		// 	path: '/static-assets/files/',
+		// 	// onFileAdded: (file) => {
+		// 	// 	console.log('file', file);
+		// 	// },
+		// 	onUploadComplete: (result) => {
+		// 		console.log('result', result);
+		// 	}
+		// });
+		// dispatch(
+		// 	pushDialog({
+		// 		component: createComponentId('ImageEditorDialog'),
+		// 		props: {
+		// 			path: '/static-assets/images/book-woman-pic.jpg',
+		// 			writeContent: true,
+		// 			restrictions
+		// 			// modes: ['rotate']
+		// 		}
+		// 	})
+		// );
+
+		// e.g. now+2d, now-3weeks, now+1years, now-4hours, now+30minutes
+		const processed = processPopulateExpression({
+			// expression: '{friday} 09:00:00',
+			// expression: '{now+2d} 09:00:00',
+			// expression: '{now+2d}',
+			// expression: '{now+1years}',
+			// expression: '{thursday}',
+			expression: exp,
+			validatePopulateExpression: validateDatePopulateExpression,
+			allowPastDate: false
+		});
+
+		setProcessed(processed);
+		// console.log('exp', processed);
+
+		// fetchContentItem(siteId, '/site/website/index.xml').subscribe((item) => {
+		// 	setItem(item);
+		// });
+	}, [dispatch, exp]);
+
+	return (
+		<>
+			<Box sx={{ p: 2 }}>
+				<TextField
+					label="Exp"
+					variant="outlined"
+					value={exp}
+					onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
+						setExp(event.target.value);
+					}}
+				/>
+				<div>{processed?.toString()}</div>
+			</Box>
+			{/*<ContentTypeManagement />*/}
+			{/*<FormsEngine update={{ path: '/site/website/index.xml' }} />*/}
+			{/*<FormsEngine update={{ path: '/site/website/tests/index.xml' }} />*/}
+			{/*<FormsEngine update={{ path: '/site/components/features/4be0a368-783c-8f73-7469-63a62636bd4c.xml' }} />*/}
+			{/* <FormsEngine update={{ path: '/site/website/asd/index.xml' }} />*/}
+			{/* <SingleFileUpload
+				site={siteId}
+				path="/static-assets/images"
+				onFileAdded={(file, uppy, callback) => {
+					const data = file.data; // is a Blob instance
+					const url = URL.createObjectURL(data);
+					const image = new Image();
+					image.src = url;
+					image.onload = () => {
+						if (!imageMeetRestrictions(image, restrictions)) {
+							const dialogId = nanoid();
+							dispatch(
+								pushDialog({
+									id: dialogId,
+									component: createComponentId('ImageEditorDialog'),
+									props: {
+										path: url,
+										restrictions,
+										onCrop: (blob: Blob) => {
+											dispatch(popDialog({ id: dialogId }));
+											uppy.setFileState(file.id, {
+												...file.meta,
+												source: 'crop',
+												name: file.name,
+												type: blob.type,
+												data: blob
+											});
+											callback?.();
+										}
+									}
+								})
+							);
+						} else {
+							callback?.();
+						}
+					};
+				}}
+			/>*/}
+			{/*<BrowseExternalAssetDialog
+				path="/"
+				profileId="s3-default"
+				open={true}
+				multiSelect
+				preselectedPaths={['/remote-assets/s3/s3-default/nature-backgrounds.jpg']}
+				onSuccess={(selection) => {
+					console.log('selection', selection);
+				}}
+			/>*/}
+			{/* webdav */}
+			{/* <BrowseExternalAssetDialog
+				path="/"
+				profileId="webdav-default"
+				open={false}
+				profileType="webdav"
+				// multiSelect
+				// preselectedPaths={['/remote-assets/s3/s3-default/nature-backgrounds.jpg']}
+				onSuccess={(selection) => {
+					console.log('selection', selection);
+				}}
+			/>*/}
+			<BrowseFilesDialog
+				path="/static-assets/images"
+				open={false}
+				multiSelect
+				preselectedPaths={['/static-assets/images/get-in-shape-pic.jpg']}
+				onSuccess={(selection) => {
+					console.log('selection', selection);
+				}}
+			/>
+			{/* <ExternalAssetUploadDialog onClose={() => {}} open={false} path="/" profileId="s3-default" />
+			<ExternalAssetUploadDialog
+				onClose={() => {
+					console.log('close!');
+				}}
+				open={false}
+				path="/"S
+				profileId="webdav-default"
+				profileType="webdav"
+			/>*/}
+			{/* <SingleFileUploadDialog onClose={() => {}} site={siteId} path={'/stati-assets/images'} open={true} />*/}
+			{/* <LoadingState /> */}
+		</>
+	);
+}
+
+createRoot(document.getElementById('root')).render(
+	<CrafterCMSNextBridge>
+		{/* <App /> */}
+		<Preview />
+		{/* <Login /> */}
+		{/* <Global passwordRequirementsMinComplexity={3} footerHtml="" /> */}
+	</CrafterCMSNextBridge>
+);


### PR DESCRIPTION
https://github.com/craftersoftware/craftercms/issues/8053

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Content retrieval now supports configurable flattening for items, children, descriptors, and trees.
  - Redux item-loading actions accept URLs together with optional content configuration.
  - Search actions now use a dedicated search action type.

- **Breaking Changes**
  - Descriptor-specific content and Redux actions are no longer available; use item or tree retrieval instead.
  - Updated package versions and dependency releases are included across the JavaScript SDK.

- **Documentation**
  - SDK content and Redux usage examples and API references were updated for the revised interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->