### PR TITLE
[8339] TB2 Updates

### DIFF
--- a/studio-ui/ui/app/src/components/ContentTypeManagement/components/EditTypeView.tsx
+++ b/studio-ui/ui/app/src/components/ContentTypeManagement/components/EditTypeView.tsx
@@ -393,6 +393,7 @@ export const EditTypeView = forwardRef<HTMLDivElement, EditTypeAppProps>((props,
 
 	const effectRefs = useUpdateRefs({
 		jotai,
+		open,
 		selectedFieldIdPath,
 		fieldPathsWithErrors,
 		activeFormHasErrors,
@@ -751,6 +752,8 @@ export const EditTypeView = forwardRef<HTMLDivElement, EditTypeAppProps>((props,
 	// `fieldUpdates$` subscription
 	useEffect(() => {
 		const sub = stateRef.current.fieldUpdates$.pipe(debounceTime(500)).subscribe(async () => {
+			// Ignore queued updates after close/rollback so they can't re-dirty or write stale values.
+			if (!effectRefs.current.open) return;
 			const { fieldPathsWithErrors, selectedFieldIdPath, onUpdateHasPendingChanges, jotai } = effectRefs.current;
 			onUpdateHasPendingChanges(true);
 			stateRef.current.formFieldsChanged = true;

--- a/studio-ui/ui/app/src/components/ContentTypeManagement/components/EditTypeView.tsx
+++ b/studio-ui/ui/app/src/components/ContentTypeManagement/components/EditTypeView.tsx
@@ -724,10 +724,14 @@ export const EditTypeView = forwardRef<HTMLDivElement, EditTypeAppProps>((props,
 	};
 
 	const handleReorderSectionFields = (fields: ReorderFieldsDialogProps['fields'], sectionId: string) => {
+		onUpdateHasPendingChanges(true);
 		setType((currentType) => {
 			const nextType = reorderSectionFields(currentType, fields, sectionId);
-			const nextSection = getSectionFromType(nextType, sectionId);
-			handleSectionSelected(nextSection, nextType);
+			// Refresh the section form when that section is already open in the drawer.
+			if (fieldFormViewProps?.section?.id === sectionId) {
+				const nextSection = getSectionFromType(nextType, sectionId);
+				handleSectionSelected(nextSection, nextType);
+			}
 			return nextType;
 		});
 	};
@@ -839,6 +843,7 @@ export const EditTypeView = forwardRef<HTMLDivElement, EditTypeAppProps>((props,
 						onFieldSelected={handleFieldSelected}
 						onDataSourceSelected={handleDataSourceSelected}
 						onSectionSelected={handleSectionSelected}
+						onReorderSectionFields={handleReorderSectionFields}
 						fieldPathsWithErrors={fieldPathsWithErrors}
 						selectedFieldIdPath={selectedFieldIdPath}
 						performCurrentFormErrorCheckAndWarning={performCurrentFormErrorCheckAndWarning}

--- a/studio-ui/ui/app/src/components/ContentTypeManagement/components/EditTypeView.tsx
+++ b/studio-ui/ui/app/src/components/ContentTypeManagement/components/EditTypeView.tsx
@@ -751,14 +751,14 @@ export const EditTypeView = forwardRef<HTMLDivElement, EditTypeAppProps>((props,
 	// `fieldUpdates$` subscription
 	useEffect(() => {
 		const sub = stateRef.current.fieldUpdates$.pipe(debounceTime(500)).subscribe(async () => {
-			const { fieldPathsWithErrors, selectedFieldIdPath, onUpdateHasPendingChanges } = effectRefs.current;
+			const { fieldPathsWithErrors, selectedFieldIdPath, onUpdateHasPendingChanges, jotai } = effectRefs.current;
 			onUpdateHasPendingChanges(true);
 			stateRef.current.formFieldsChanged = true;
 			const nextFieldPathsWithErrors = { ...fieldPathsWithErrors };
 			// Check validation atoms of the form to see if there are any unfulfilled validations.
 			setValidatingForm(true);
 			const hasErrors = await validityAtomsHaveErrors(
-				effectRefs.current.jotai,
+				jotai,
 				stateRef.current?.activeFormContext?.atoms?.validationByFieldId
 			);
 			setActiveFormHasErrors(hasErrors);
@@ -767,6 +767,19 @@ export const EditTypeView = forwardRef<HTMLDivElement, EditTypeAppProps>((props,
 
 			setFieldPathsWithErrors(nextFieldPathsWithErrors);
 			setValidatingForm(false);
+
+			// Live-sync draft thumbnailFileName while the type properties form is open,
+			// so TypeCardMedia can reload by filename without waiting for form commit / save.
+			const { selectedField, selectedSection, selectedDataSource, activeFormContext } = stateRef.current;
+			if (!selectedField && !selectedSection && !selectedDataSource && activeFormContext) {
+				const thumbnailAtom = activeFormContext.atoms.valueByFieldId.thumbnailFileName;
+				if (thumbnailAtom) {
+					const thumbnailFileName = (jotai.get(thumbnailAtom) as string) || null;
+					setType((current) =>
+						current.thumbnailFileName === thumbnailFileName ? current : { ...current, thumbnailFileName }
+					);
+				}
+			}
 		});
 		return () => {
 			sub.unsubscribe();

--- a/studio-ui/ui/app/src/components/ContentTypeManagement/components/PickControlDialog.tsx
+++ b/studio-ui/ui/app/src/components/ContentTypeManagement/components/PickControlDialog.tsx
@@ -21,9 +21,9 @@ import controlDescriptors from '../descriptors/controls';
 import { nou } from '../../../utils/object';
 import { ContentType, ContentTypeField } from '../../../models';
 import PickFieldDialog from './PickFieldDialog';
-import { BuiltInControlType } from '../../FormsEngine/lib/controlMap';
 import { DescriptorContentType } from '../utils';
 import { ContentTypeManagementConfig } from './EditTypeView';
+import { systemFieldsIds } from '../../../utils/constants';
 
 export interface PickControlDialogProps extends EnhancedDialogProps {
 	sectionId: string;
@@ -36,18 +36,6 @@ export interface PickControlDialogProps extends EnhancedDialogProps {
 }
 
 const types = Object.values(controlDescriptors).sort((a, b) => (a?.name > b?.name ? 1 : -1));
-
-// TODO: finalize handling of systemFields
-export const systemFieldsIds: BuiltInControlType[] = [
-	'file-name',
-	'auto-filename',
-	'internal-name',
-	'disabled',
-	'page-nav-order',
-	'locale-selector',
-	'expired-date',
-	'forcehttps'
-];
 
 export function PickControlDialog(props: PickControlDialogProps) {
 	const {

--- a/studio-ui/ui/app/src/components/ContentTypeManagement/components/SwapFieldDialog.tsx
+++ b/studio-ui/ui/app/src/components/ContentTypeManagement/components/SwapFieldDialog.tsx
@@ -24,7 +24,7 @@ import { SelectField } from './PickFieldDialog';
 import { DialogFooter } from '../../DialogFooter';
 import SecondaryButton from '../../SecondaryButton';
 import PrimaryButton from '../../PrimaryButton';
-import { systemFieldsIds } from './PickControlDialog';
+import { systemFieldsIds } from '../../../utils/constants';
 
 export interface SwapFieldDialogProps extends EnhancedDialogProps {
 	currentFieldType: string;

--- a/studio-ui/ui/app/src/components/ContentTypeManagement/components/TypeCard.tsx
+++ b/studio-ui/ui/app/src/components/ContentTypeManagement/components/TypeCard.tsx
@@ -79,7 +79,12 @@ export function TypeCard(props: TypeCardProps) {
 					content: { sx: { overflow: 'hidden' } }
 				}}
 			/>
-			<TypeCardMedia skeleton={skeleton} typeId={type?.id} sx={styleOverrides?.cardMedia} />
+			<TypeCardMedia
+				skeleton={skeleton}
+				typeId={type?.id}
+				thumbnailFileName={type?.thumbnailFileName}
+				sx={styleOverrides?.cardMedia}
+			/>
 		</>
 	);
 	return (

--- a/studio-ui/ui/app/src/components/ContentTypeManagement/components/TypeCardMedia.tsx
+++ b/studio-ui/ui/app/src/components/ContentTypeManagement/components/TypeCardMedia.tsx
@@ -17,36 +17,47 @@
 import React, { useEffect, useRef } from 'react';
 import useActiveSiteId from '../../../hooks/useActiveSiteId';
 import { useTheme } from '@mui/material/styles';
-import { fetchPreviewImage } from '../../../services/contentTypes';
+import { fetchContentTypePreviewImageUrl } from '../../../services/contentTypes';
 import CardMedia, { CardMediaProps } from '@mui/material/CardMedia';
 import { consolidateSx } from '../../../utils/system';
 import Skeleton from '@mui/material/Skeleton';
 
 export interface ContentTypeCardMediaProps extends CardMediaProps {
 	typeId: string;
+	thumbnailFileName?: string;
 	skeleton?: boolean;
 }
 
 export function TypeCardMedia(props: ContentTypeCardMediaProps) {
-	const { typeId, sx, skeleton, ...cardMediaProps } = props;
+	const { typeId, thumbnailFileName, sx, skeleton, ...cardMediaProps } = props;
 	const elementRef = useRef<HTMLImageElement>(undefined);
 	const siteId = useActiveSiteId();
 	const theme = useTheme();
 	useEffect(() => {
 		if (!typeId) return;
-		const sub = fetchPreviewImage(siteId, typeId).subscribe((response) => {
+		let objectUrl: string | undefined;
+		const sub = fetchContentTypePreviewImageUrl(siteId, typeId, thumbnailFileName || undefined).subscribe((imgUrl) => {
 			const img = elementRef.current;
-			const imgUrl = URL.createObjectURL(new Blob([response.response]));
+			if (!img) {
+				if (imgUrl.startsWith('blob:')) URL.revokeObjectURL(imgUrl);
+				return;
+			}
+			const isObjectUrl = imgUrl.startsWith('blob:');
+			if (isObjectUrl) objectUrl = imgUrl;
 			img.src = imgUrl;
-			img.onload = () => {
-				// Image has loaded, revoke the object URL to free memory.
-				URL.revokeObjectURL(imgUrl);
-			};
+			if (isObjectUrl) {
+				img.onload = () => {
+					// Image has loaded, revoke the object URL to free memory.
+					URL.revokeObjectURL(imgUrl);
+					if (objectUrl === imgUrl) objectUrl = undefined;
+				};
+			}
 		});
 		return () => {
 			sub.unsubscribe();
+			if (objectUrl) URL.revokeObjectURL(objectUrl);
 		};
-	}, [siteId, typeId]);
+	}, [siteId, typeId, thumbnailFileName]);
 	return (
 		<CardMedia
 			sx={consolidateSx(

--- a/studio-ui/ui/app/src/components/ContentTypeManagement/components/TypeDetailsView.tsx
+++ b/studio-ui/ui/app/src/components/ContentTypeManagement/components/TypeDetailsView.tsx
@@ -41,6 +41,8 @@ import LookupTable from '../../../models/LookupTable';
 import { atom } from 'jotai';
 import SectionInsertionDialog, { SectionInsertionProps } from './SectionInsertionDialog';
 import { defaultDataSourcesSection } from '../descriptors/controls/commonDescriptors';
+import MoveDownIcon from '@mui/icons-material/MoveDown';
+import { ReorderFieldsDialog, type ReorderFieldsDialogProps } from './ReorderFieldsDialog';
 
 export interface TypeDetailsViewProps {
 	type: PossibleContentTypeDraft;
@@ -53,6 +55,7 @@ export interface TypeDetailsViewProps {
 	onInsertSection: SectionInsertionProps['onInsertSection'];
 	onOpenInsertFieldDialog(sectionId: string, fieldPath?: string): void;
 	onOpenInsertDataSourceDialog(): void;
+	onReorderSectionFields?(fields: ReorderFieldsDialogProps['fields'], sectionId: string): void;
 	performCurrentFormErrorCheckAndWarning?(): boolean;
 }
 
@@ -67,6 +70,7 @@ export function TypeDetailsView(props: TypeDetailsViewProps) {
 		onEditTypeAction,
 		onOpenInsertFieldDialog,
 		onOpenInsertDataSourceDialog,
+		onReorderSectionFields,
 		performCurrentFormErrorCheckAndWarning
 	} = props;
 
@@ -76,6 +80,7 @@ export function TypeDetailsView(props: TypeDetailsViewProps) {
 		stableFormContextRef.current = createStableFormContextProps({ type }, true);
 
 	const [openSectionInserter, setOpenSectionInserter] = useState<boolean>(false);
+	const [reorderSectionId, setReorderSectionId] = useState<string>(null);
 
 	const onAddSection = () => {
 		if (!performCurrentFormErrorCheckAndWarning()) return false;
@@ -115,6 +120,19 @@ export function TypeDetailsView(props: TypeDetailsViewProps) {
 
 	const handleDataSourceSelected = (_, field) => {
 		onDataSourceSelected?.(type.dataSources.find((dataSource) => dataSource.id === field.id));
+	};
+
+	const reorderSection = type.sections.find((section) => section.id === reorderSectionId);
+	const reorderFields =
+		reorderSection?.fields.map((fieldId) => ({
+			key: fieldId,
+			value: type.fields[fieldId]?.name ?? fieldId
+		})) ?? [];
+
+	const handleReorderFields = (fields: ReorderFieldsDialogProps['fields']) => {
+		const sectionId = reorderSectionId;
+		setReorderSectionId(null);
+		onReorderSectionFields?.(fields, sectionId);
 	};
 
 	return (
@@ -168,9 +186,18 @@ export function TypeDetailsView(props: TypeDetailsViewProps) {
 								/>
 							)}
 						>
-							<Button sx={{ position: 'absolute', top: 15, right: 10 }} onClick={() => onSectionSelected?.(section)}>
-								<FormattedMessage defaultMessage="Edit" />
-							</Button>
+							<Box sx={{ position: 'absolute', top: 15, right: 10 }}>
+								{section.fields?.length > 0 && (
+									<Tooltip title={<FormattedMessage defaultMessage="Reorder fields" />}>
+										<IconButton onClick={() => setReorderSectionId(section.id)}>
+											<MoveDownIcon />
+										</IconButton>
+									</Tooltip>
+								)}
+								<Button onClick={() => onSectionSelected?.(section)}>
+									<FormattedMessage defaultMessage="Edit" />
+								</Button>
+							</Box>
 						</SectionAccordion>
 					))}
 
@@ -205,6 +232,12 @@ export function TypeDetailsView(props: TypeDetailsViewProps) {
 						open={openSectionInserter}
 						onClose={() => setOpenSectionInserter(false)}
 						onInsertSection={handleInsertSection}
+					/>
+					<ReorderFieldsDialog
+						fields={reorderFields}
+						open={Boolean(reorderSectionId)}
+						onClose={() => setReorderSectionId(null)}
+						onReorderFields={handleReorderFields}
 					/>
 				</StableFormContext.Provider>
 			</Provider>

--- a/studio-ui/ui/app/src/components/ContentTypeManagement/components/TypeDetailsViewHeader.tsx
+++ b/studio-ui/ui/app/src/components/ContentTypeManagement/components/TypeDetailsViewHeader.tsx
@@ -58,7 +58,7 @@ export function TypeDetailsViewHeader({ type, onActionClick }: TypeDetailsViewHe
 	};
 	return (
 		<Box display="flex" gap={1}>
-			<TypeCardMedia typeId={type.id} sx={{ width: 200, height: 200 }} />
+			<TypeCardMedia typeId={type.id} thumbnailFileName={type.thumbnailFileName} sx={{ width: 200, height: 200 }} />
 			<Box>
 				<Typography variant="body2" color="textSecondary">
 					{type.id}
@@ -70,7 +70,8 @@ export function TypeDetailsViewHeader({ type, onActionClick }: TypeDetailsViewHe
 				<Typography variant="body2" color="textSecondary" mb={0.5}>
 					{type.description || <FormattedMessage defaultMessage="(no description)" />}
 				</Typography>
-				<Typography variant="body2" color="textSecondary" mb={0.5}>
+				{/* TODO: Add last updated information - There's a pending conversation to include this in the form-definition */}
+				{/* <Typography variant="body2" color="textSecondary" mb={0.5}>
 					<FormattedMessage
 						defaultMessage="Last updated on <b>{date}</b> by <b>{user}</b>"
 						values={{
@@ -80,7 +81,7 @@ export function TypeDetailsViewHeader({ type, onActionClick }: TypeDetailsViewHe
 							b: (text) => <strong key={text[0] as string}>{text[0]}</strong>
 						}}
 					/>
-				</Typography>
+				</Typography> */}
 				<Button onClick={handleActionClick} data-action-target="properties">
 					<FormattedMessage defaultMessage="Properties" />
 				</Button>

--- a/studio-ui/ui/app/src/components/ContentTypeManagement/controls/TypeImageSelector.tsx
+++ b/studio-ui/ui/app/src/components/ContentTypeManagement/controls/TypeImageSelector.tsx
@@ -101,6 +101,7 @@ export function TypeImageSelector(props: TypeImageSelectorProps) {
 											restrictions: TYPE_IMAGE_RESTRICTIONS,
 											writeContent: false,
 											onCrop: (blob: Blob) => {
+												URL.revokeObjectURL(objectUrl);
 												const formData = new FormData();
 												formData.append('file', blob, uploaded.name);
 												formData.append('path', path);

--- a/studio-ui/ui/app/src/components/ContentTypeManagement/controls/TypeImageSelector.tsx
+++ b/studio-ui/ui/app/src/components/ContentTypeManagement/controls/TypeImageSelector.tsx
@@ -18,7 +18,7 @@ import OutlinedInput, { OutlinedInputProps } from '@mui/material/OutlinedInput';
 import React, { useId } from 'react';
 import FormsEngineField from '../../FormsEngine/components/FormsEngineField';
 import Tooltip from '@mui/material/Tooltip';
-import { FormattedMessage } from 'react-intl';
+import { FormattedMessage, useIntl } from 'react-intl';
 import { useDispatch } from 'react-redux';
 import { popDialog, pushDialog } from '../../../state/actions/dialogStack';
 import { nanoid } from 'nanoid';
@@ -28,25 +28,35 @@ import UploadRoundedIcon from '@mui/icons-material/UploadRounded';
 import useActiveSiteId from '../../../hooks/useActiveSiteId';
 import { useStableFormContext } from '../../FormsEngine/lib/formsEngineContext';
 import { TypeBuilderControl } from '../utils';
+import type { ImageRestrictions } from '../../ImageEditorDialog/types';
+import { showImageCropDialog } from '../../FormsEngine/lib/controlHelpers';
+import { validateImageRestrictions } from '../../../utils/content';
+import { showSystemNotification } from '../../../state/actions/system';
+import { ensureSingleSlash } from '../../../utils/string';
+import { getFileNameFromPath } from '../../../utils/path';
+import { uploadFile } from '../../../services/content';
+import { pushErrorDialog } from '../../../utils/system';
 
 export interface TypeImageSelectorProps extends TypeBuilderControl {
 	value: string;
 }
 
-// TODO: in legacy - there are image size restrictions, and the cropper was shown if the image was too large
-/*
-	WIDTHCONSTRAINS = 775;
-	HEIGHTCONSTRAINS = 767;
-*/
+/** Content-type thumbnail size caps (WIDTHCONSTRAINS / HEIGHTCONSTRAINS). */
+const TYPE_IMAGE_RESTRICTIONS: ImageRestrictions = {
+	maxWidth: 775,
+	maxHeight: 767
+};
 
 /**
  * Enables image selection through the ImageUploadDialog.
+ * Opens ImageEditorDialog to crop when the upload exceeds the size restrictions.
  */
 export function TypeImageSelector(props: TypeImageSelectorProps) {
 	const { field, value, setValue, autoFocus } = props;
 	const htmlId = useId();
 	const siteId = useActiveSiteId();
 	const dispatch = useDispatch();
+	const { formatMessage } = useIntl();
 	const basePath = '/config/studio/content-types';
 	const stableFormContext = useStableFormContext();
 	// stableFormContext.originalValues is of type `ContentType`, and `id` is the current contentTypeId.
@@ -70,20 +80,59 @@ export function TypeImageSelector(props: TypeImageSelectorProps) {
 					fileTypes: ['image/*'],
 					onClose: () => dispatch(popDialog({ id })),
 					onUploadComplete: (result) => {
+						dispatch(popDialog({ id }));
 						if (result.successful.length) {
 							const uploaded = result.successful[0];
-							setValue(uploaded.name);
+							const path = uploaded.meta?.path ?? ensureSingleSlash(`${basePath}${contentTypeId}/${uploaded.name}`);
+							const mimeType = uploaded.type;
+							// Config-folder paths aren't loadable as img src; use a blob URL for validation / cropper display.
+							const objectUrl = URL.createObjectURL(uploaded.data);
+							validateImageRestrictions(objectUrl, TYPE_IMAGE_RESTRICTIONS, mimeType)
+								.then((meetsRestrictions) => {
+									if (meetsRestrictions) {
+										URL.revokeObjectURL(objectUrl);
+										setValue(uploaded.name);
+									} else {
+										// Blob URLs force writeContent: false in showImageCropDialog; upload the cropped result ourselves.
+										showImageCropDialog({
+											dispatch,
+											path: objectUrl,
+											mimeType,
+											restrictions: TYPE_IMAGE_RESTRICTIONS,
+											writeContent: false,
+											onCrop: (blob: Blob) => {
+												const formData = new FormData();
+												formData.append('file', blob, uploaded.name);
+												formData.append('path', path);
+												uploadFile(siteId, formData).subscribe({
+													next: () => setValue(getFileNameFromPath(path)),
+													error: ({ response }) => {
+														dispatch(pushErrorDialog({ props: { error: response?.response } }));
+													}
+												});
+											}
+										});
+									}
+								})
+								.catch(() => {
+									URL.revokeObjectURL(objectUrl);
+									dispatch(
+										showSystemNotification({
+											message: formatMessage({ defaultMessage: 'Unable to validate image restrictions.' })
+										})
+									);
+								});
 						} else if (result.failed.length) {
-							// Show error notification or alert
-							dispatch({
-								type: 'SHOW_SYSTEM_NOTIFICATION',
-								payload: {
-									message: `Failed to upload image: ${result.failed[0]?.name}`,
+							dispatch(
+								showSystemNotification({
+									message: formatMessage(
+										{ defaultMessage: 'Failed to upload image: {name}' },
+										{ name: result.failed[0]?.name }
+									),
 									options: { variant: 'error' }
-								}
-							});
+								})
+							);
 						}
-						dispatch(popDialog({ id }));
 					}
 				}
 			})

--- a/studio-ui/ui/app/src/services/contentTypes.ts
+++ b/studio-ui/ui/app/src/services/contentTypes.ts
@@ -30,7 +30,7 @@ import {
 	ValidationKeys
 } from '../models/ContentType';
 import { LookupTable } from '../models/LookupTable';
-import { camelize, capitalize, isBlank, toColor } from '../utils/string';
+import { camelize, capitalize, ensureSingleSlash, isBlank, toColor } from '../utils/string';
 import { Observable, of } from 'rxjs';
 import { CONTENT_TYPE_JSON, get, getBinary, getGlobalHeaders, post } from '../utils/ajax';
 import { map, switchMap } from 'rxjs/operators';
@@ -679,7 +679,7 @@ export function fetchContentTypePreviewImageUrl(
 	thumbnailFileName?: string
 ): Observable<string> {
 	if (thumbnailFileName) {
-		const path = `/config/studio/content-types${contentTypeId}/${thumbnailFileName}`;
+		const path = ensureSingleSlash(`/config/studio/content-types/${contentTypeId}/${thumbnailFileName}`);
 		return getBinary(
 			`/studio/api/2/content/get_content_by_commit_id${toQueryString({ siteId: site, path, commitId: 'HEAD' })}`,
 			void 0,

--- a/studio-ui/ui/app/src/services/contentTypes.ts
+++ b/studio-ui/ui/app/src/services/contentTypes.ts
@@ -50,6 +50,7 @@ import {
 } from '../utils/contentType';
 import { XmlKeys } from '../components/FormsEngine/lib/formConsts';
 import { ajax, AjaxResponse } from 'rxjs/ajax';
+import { DEFAULT_CONTENT_TYPE_PREVIEW_IMAGE_URL } from '../utils/constants';
 
 // FE2 TODO: Verify removal
 // const typeMap = {
@@ -664,6 +665,28 @@ export function dissociateTemplate(site: string, contentTypeId: string): Observa
 export function fetchPreviewImage(site: string, contentTypeId: string): Observable<AjaxResponse<Blob>> {
 	const qs = toQueryString({ contentTypeId });
 	return getBinary(`/studio/api/2/configuration/content_types/${site}/preview_image${qs}`);
+}
+
+/**
+ * Returns a URL for a content type thumbnail.
+ * When `thumbnailFileName` is provided, loads that file from the type's config folder (works with unsaved draft filenames)
+ * and returns an object URL. When empty/absent, returns the static default placeholder (does not use preview_image,
+ * which would still serve the saved form-definition thumbnail until save).
+ */
+export function fetchContentTypePreviewImageUrl(
+	site: string,
+	contentTypeId: string,
+	thumbnailFileName?: string
+): Observable<string> {
+	if (thumbnailFileName) {
+		const path = `/config/studio/content-types${contentTypeId}/${thumbnailFileName}`;
+		return getBinary(
+			`/studio/api/2/content/get_content_by_commit_id${toQueryString({ siteId: site, path, commitId: 'HEAD' })}`,
+			void 0,
+			'blob'
+		).pipe(map((ajax) => URL.createObjectURL(ajax.response as Blob)));
+	}
+	return of(DEFAULT_CONTENT_TYPE_PREVIEW_IMAGE_URL);
 }
 
 /**

--- a/studio-ui/ui/app/src/utils/constants.ts
+++ b/studio-ui/ui/app/src/utils/constants.ts
@@ -17,6 +17,7 @@
 // region State
 //                                                          6 |    5    |    4    |    3    |    2    |    1    |     0
 //                                                         321|987654321|987654321|987654321|987654321|987654321|9876543210
+import { BuiltInControlType } from '../components/FormsEngine/lib/controlMap';
 import PluginDescriptorWithSource from '../models/PluginDescriptorWithSource';
 import WidgetRecord from '../models/WidgetRecord';
 
@@ -134,3 +135,14 @@ export const PACKAGE_TYPE_INITIAL_PUBLISH = 'INITIAL_PUBLISH';
 
 export const webDAVUploadUri = '/api/2/webdav/upload';
 export const s3UploadUri = '/api/2/aws/s3/upload.json';
+
+export const systemFieldsIds: BuiltInControlType[] = [
+	'file-name',
+	'auto-filename',
+	'internal-name',
+	'disabled',
+	'page-nav-order',
+	'locale-selector',
+	'expired-date',
+	'forcehttps'
+];

--- a/studio-ui/ui/app/src/utils/constants.ts
+++ b/studio-ui/ui/app/src/utils/constants.ts
@@ -146,3 +146,7 @@ export const systemFieldsIds: BuiltInControlType[] = [
 	'expired-date',
 	'forcehttps'
 ];
+
+/** Static placeholder used when a content type has no thumbnail ("Screenshot not set"). */
+export const DEFAULT_CONTENT_TYPE_PREVIEW_IMAGE_URL =
+	'/studio/static-assets/themes/cstudioTheme/images/default-contentType.jpg';


### PR DESCRIPTION
- Add 'Reorder Fields' action to section accordion
- Move systemFieldsIds constant to constants file
- Remove 'Last updated ...' since form-definition.xml doesn't have the info
- Fix Thumbnail Image not reflecting the new image. Update to read from atom instead of reading from xml.

https://github.com/craftersoftware/craftercms/issues/8339

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the ability to reorder fields within content type sections.
  * Content type cards display configured thumbnail images, with a default preview when none is available.
  * Thumbnail changes are reflected immediately while editing content type properties.
  * Added image validation and cropping for content type thumbnails, including 775×767 size requirements.

* **Bug Fixes**
  * Improved section editing synchronization and rollback handling.
  * Improved thumbnail loading and cleanup for more reliable previews.
  * The last-updated display is no longer shown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->