### PR TITLE
Drop xml output from RestScriptsController

### DIFF
--- a/engine/src/main/java/org/craftercms/engine/controller/rest/RestScriptsController.java
+++ b/engine/src/main/java/org/craftercms/engine/controller/rest/RestScriptsController.java
@@ -112,7 +112,7 @@ public class RestScriptsController implements ServletContextAware {
         this.pluginService = pluginService;
     }
 
-    @RequestMapping(path = "/**", produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_XML_VALUE})
+    @RequestMapping(path = "/**", produces = {MediaType.APPLICATION_JSON_VALUE})
     protected ResponseEntity handleRequest(final HttpServletRequest request, final HttpServletResponse response) {
         SiteContext siteContext = SiteContext.getCurrent();
         ScriptFactory scriptFactory = siteContext.getScriptFactory();


### PR DESCRIPTION
Drop xml output from RestScriptsController
https://github.com/craftersoftware/craftercms/issues/9015

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * REST script responses now declare only the `application/json` media type; `application/xml` is no longer advertised.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->