### PR TITLE
Exclude conflicting xerces java to avoid unsupported properties error

### DIFF
--- a/commons/validation/build.gradle
+++ b/commons/validation/build.gradle
@@ -31,7 +31,11 @@ dependencies {
 
 	implementation libs.commons.lang3
 	implementation libs.jakarta.validation.api
-	implementation("org.owasp.esapi:esapi:${libs.versions.esapi.get()}:jakarta")
+	implementation("org.owasp.esapi:esapi:${libs.versions.esapi.get()}:jakarta") {
+		// Keep standalone Xerces out of the published POM; it breaks OpenSAML's parser pool
+		exclude group: 'xerces', module: 'xercesImpl'
+		exclude group: 'xml-apis', module: 'xml-apis'
+	}
 	implementation libs.hibernate.validator
 	implementation libs.spring.context
 	implementation libs.spring.context.support

--- a/gradle/java-library.gradle
+++ b/gradle/java-library.gradle
@@ -27,6 +27,14 @@ plugins.withType(JavaPlugin).configureEach {
 		withJavadocJar()
 	}
 
+	configurations.configureEach {
+		// OpenSAML 5.2.2+ sets jdk.xml.* attributes on its parser pool that standalone
+		// Xerces does not implement (XERCESJ-1759), so the JDK JAXP parser must win the
+		// DocumentBuilderFactory service lookup. xml-apis only shadows java.xml classes.
+		exclude group: 'xerces', module: 'xercesImpl'
+		exclude group: 'xml-apis', module: 'xml-apis'
+	}
+
 	tasks.withType(JavaCompile).configureEach {
 		options.encoding = 'UTF-8'
 		options.compilerArgs += ['-parameters']


### PR DESCRIPTION
Exclude conflicting xerces java to avoid unsupported properties error
https://github.com/craftersoftware/craftercms-e/issues/1328

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved XML parsing consistency across supported environments.
  - Reduced conflicts caused by competing parser implementations, helping applications reliably use the platform’s standard XML processing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->